### PR TITLE
fix(output): show PROJECT and DUE_AT columns for next-action lists

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -356,6 +356,108 @@ func TestEngageNextAction(t *testing.T) {
 	}
 }
 
+func TestEngageNextActionIncludesDueToday(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	todayMidnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+	due := nowItem("20260420-due_today", model.KindNextAction, model.StatusActive)
+	due.DueAt = &todayMidnight
+	writeItem(t, dir, due, "")
+
+	past := todayMidnight.Add(-24 * time.Hour)
+	overdue := nowItem("20260420-overdue", model.KindNextAction, model.StatusActive)
+	overdue.DueAt = &past
+	writeItem(t, dir, overdue, "")
+
+	future := todayMidnight.Add(48 * time.Hour)
+	upcoming := nowItem("20260420-upcoming", model.KindNextAction, model.StatusActive)
+	upcoming.DueAt = &future
+	writeItem(t, dir, upcoming, "")
+
+	out, _, err := runCmd(t, dir, "engage", "next-action")
+	if err != nil {
+		t.Fatalf("engage next-action: %v", err)
+	}
+	for _, id := range []string{"20260420-due_today", "20260420-overdue", "20260420-upcoming"} {
+		if !strings.Contains(out, id) {
+			t.Errorf("missing %s: %q", id, out)
+		}
+	}
+}
+
+func TestEngageNextActionSortsByDueAt(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	yesterday := today.Add(-24 * time.Hour)
+	tomorrow := today.Add(24 * time.Hour)
+
+	a := nowItem("20260420-a_tomorrow", model.KindNextAction, model.StatusActive)
+	a.DueAt = &tomorrow
+	b := nowItem("20260420-b_yesterday", model.KindNextAction, model.StatusActive)
+	b.DueAt = &yesterday
+	c := nowItem("20260420-c_nodue", model.KindNextAction, model.StatusActive)
+	d := nowItem("20260420-d_today", model.KindNextAction, model.StatusActive)
+	d.DueAt = &today
+	writeItem(t, dir, a, "")
+	writeItem(t, dir, b, "")
+	writeItem(t, dir, c, "")
+	writeItem(t, dir, d, "")
+
+	out, _, err := runCmd(t, dir, "engage", "next-action")
+	if err != nil {
+		t.Fatalf("engage next-action: %v", err)
+	}
+
+	want := []string{
+		"20260420-b_yesterday",
+		"20260420-d_today",
+		"20260420-a_tomorrow",
+		"20260420-c_nodue",
+	}
+	var positions []int
+	for _, id := range want {
+		idx := strings.Index(out, id)
+		if idx < 0 {
+			t.Fatalf("missing %s in output: %q", id, out)
+		}
+		positions = append(positions, idx)
+	}
+	for i := 1; i < len(positions); i++ {
+		if positions[i] < positions[i-1] {
+			t.Errorf("sort order: %s should appear after %s\nout=%q", want[i], want[i-1], out)
+		}
+	}
+}
+
+func TestEngageNextActionShowsDueAtColumn(t *testing.T) {
+	dir := setupDir(t)
+	due := time.Date(2026, 4, 20, 0, 0, 0, 0, time.Local)
+
+	it := nowItem("20260420-dated", model.KindNextAction, model.StatusActive)
+	it.DueAt = &due
+	it.Project = "20260420-some_proj"
+	writeItem(t, dir, it, "")
+
+	out, _, err := runCmd(t, dir, "engage", "next-action")
+	if err != nil {
+		t.Fatalf("engage next-action: %v", err)
+	}
+	if !strings.Contains(out, "DUE_AT") {
+		t.Errorf("header should include DUE_AT column: %q", out)
+	}
+	if !strings.Contains(out, "PROJECT") {
+		t.Errorf("header should include PROJECT column: %q", out)
+	}
+	if !strings.Contains(out, "2026-04-20") {
+		t.Errorf("due_at value should appear: %q", out)
+	}
+	if !strings.Contains(out, "20260420-some_proj") {
+		t.Errorf("project value should appear: %q", out)
+	}
+}
+
 func TestEngageNextActionFilterProject(t *testing.T) {
 	dir := setupDir(t)
 	a := nowItem("20260417-na_a", model.KindNextAction, model.StatusActive)
@@ -548,6 +650,61 @@ func TestReflectNextActions(t *testing.T) {
 	}
 	if strings.Contains(out, "20260417-inbox1") {
 		t.Errorf("should not include inbox item: %q", out)
+	}
+}
+
+func TestReflectNextActionsSortsByDueAt(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	yesterday := today.Add(-24 * time.Hour)
+	tomorrow := today.Add(24 * time.Hour)
+
+	a := nowItem("20260420-r_tomorrow", model.KindNextAction, model.StatusActive)
+	a.DueAt = &tomorrow
+	b := nowItem("20260420-r_yesterday", model.KindNextAction, model.StatusActive)
+	b.DueAt = &yesterday
+	c := nowItem("20260420-r_nodue", model.KindNextAction, model.StatusActive)
+	writeItem(t, dir, a, "")
+	writeItem(t, dir, b, "")
+	writeItem(t, dir, c, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "next-actions")
+	if err != nil {
+		t.Fatalf("reflect next-actions: %v", err)
+	}
+	want := []string{"20260420-r_yesterday", "20260420-r_tomorrow", "20260420-r_nodue"}
+	var positions []int
+	for _, id := range want {
+		idx := strings.Index(out, id)
+		if idx < 0 {
+			t.Fatalf("missing %s: %q", id, out)
+		}
+		positions = append(positions, idx)
+	}
+	for i := 1; i < len(positions); i++ {
+		if positions[i] < positions[i-1] {
+			t.Errorf("sort order: %s should appear after %s\nout=%q", want[i], want[i-1], out)
+		}
+	}
+}
+
+func TestReflectNextActionsShowsDueAtColumn(t *testing.T) {
+	dir := setupDir(t)
+	due := time.Date(2026, 4, 20, 0, 0, 0, 0, time.Local)
+	it := nowItem("20260420-r_dated", model.KindNextAction, model.StatusActive)
+	it.DueAt = &due
+	writeItem(t, dir, it, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "next-actions")
+	if err != nil {
+		t.Fatalf("reflect next-actions: %v", err)
+	}
+	if !strings.Contains(out, "DUE_AT") {
+		t.Errorf("header should include DUE_AT column: %q", out)
+	}
+	if !strings.Contains(out, "2026-04-20") {
+		t.Errorf("due_at value should appear: %q", out)
 	}
 }
 

--- a/internal/command/engage.go
+++ b/internal/command/engage.go
@@ -89,7 +89,7 @@ func newEngageNextActionCommand(c *container) *cobra.Command {
 				}
 				return visible[i].DueAt.Before(*visible[j].DueAt)
 			})
-			c.printer.PrintItems(visible)
+			c.printer.PrintNextActionItems(visible)
 			return nil
 		},
 	}

--- a/internal/command/reflect.go
+++ b/internal/command/reflect.go
@@ -54,7 +54,7 @@ func newReflectNextActionsCommand(c *container) *cobra.Command {
 				}
 				return visible[i].DueAt.Before(*visible[j].DueAt)
 			})
-			c.printer.PrintItems(visible)
+			c.printer.PrintNextActionItems(visible)
 			return nil
 		},
 	}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"text/tabwriter"
+	"time"
 
 	"github.com/takai/htd/internal/model"
 )
@@ -102,6 +103,44 @@ func (p *Printer) printItemsText(items []*model.Item) {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", it.ID, it.Kind, it.Status, truncateRunes(it.Title, 40))
 	}
 	_ = tw.Flush()
+}
+
+// PrintNextActionItems prints items in the column layout specified by
+// docs/cli.md §5.1 and §6.3: ID, TITLE, PROJECT, DUE_AT. JSON output is the
+// same shape as PrintItems (full item fields) so agents retain all context.
+func (p *Printer) PrintNextActionItems(items []*model.Item) {
+	if p.json {
+		p.printItemsJSON(items)
+		return
+	}
+	tw := tabwriter.NewWriter(p.out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tTITLE\tPROJECT\tDUE_AT")
+	for _, it := range items {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			it.ID,
+			truncateRunes(it.Title, 40),
+			dashIfEmpty(it.Project),
+			formatDueAt(it.DueAt),
+		)
+	}
+	_ = tw.Flush()
+}
+
+func formatDueAt(t *time.Time) string {
+	if t == nil {
+		return "-"
+	}
+	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
+		return t.Format("2006-01-02")
+	}
+	return t.Format("2006-01-02T15:04:05Z07:00")
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
 }
 
 // truncateRunes returns s truncated to at most max runes, appending "..." if it


### PR DESCRIPTION
Closes #1.

## Summary
- `engage next-action` and `reflect next-actions` now print `ID TITLE PROJECT DUE_AT` per `docs/cli.md` §5.1/§6.3, via a new `PrintNextActionItems` in `internal/output/output.go`.
- Filter and sort were already spec-correct (active + not-deferred, ascending by `due_at` with nulls last). The actual gap was that `DUE_AT` wasn't displayed, so time-sensitive items didn't visibly surface — hence the "empty list" impression in the issue.
- `-` renders for empty project / missing due date. Date-only `due_at` prints as `YYYY-MM-DD`; datetimes keep RFC 3339.
- JSON output is unchanged (full item fields) so agents keep all context.

## Test plan
- [x] New tests covering due-today inclusion, sort order (past → today → future → no-due), and column presence for both `engage next-action` and `reflect next-actions`
- [x] Existing tests pass (`go test ./...`)
- [x] `mise run lint` clean
- [x] End-to-end repro: items with `--due yesterday|today|tomorrow` all surface with correct `DUE_AT` values and sort order