### PR TITLE
feat(organize): add promote subcommand

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -243,6 +243,45 @@ htd organize schedule ID [--due DATE] [--defer DATE] [--review DATE]
 
 At least one date option must be provided. To clear a date, pass `--due ""`.
 
+### 4.4 `htd organize promote`
+
+Promote an item to a project in one shot, creating and linking initial next-action children.
+
+```
+htd organize promote ID --child TITLE [--child TITLE]...
+```
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--child` | yes | Title of a next-action child to create and link; repeatable (at least one required) |
+
+**Behavior:**
+
+1. Find the parent item across all `items/<kind>/` directories.
+2. If the parent's `kind` is not already `project`, set `kind: project`, update `updated_at`, and move the file to `items/project/<id>.md`.
+3. For each `--child TITLE`, in order:
+   - Generate an ID via the usual `YYYYMMDD-<slug>` rule, with collision suffixing (`_2`, `_3`, ...) so same-titled siblings stay distinct.
+   - Create an item with `kind: next_action`, `status: active`, `project: <parent-id>`, and both timestamps set to now.
+   - Write it to `items/next_action/<id>.md`.
+4. Print the parent ID followed by each child ID, one per line. With `--json`, print a single object of shape `{"parent": "<id>", "children": ["<id>", ...]}`.
+
+**Constraints:**
+
+- The parent must exist and have an active status; terminal items cannot be promoted.
+- If the parent is already `kind: project`, the command skips the kind change and still creates/links the requested children (idempotent parent, additive children).
+- This command only creates next-action children; to promote a parent without adding children, use `organize move ID project`.
+
+**Example:**
+
+```
+$ htd organize promote 20260420-launch_cli \
+    --child "Verify on staging" \
+    --child "Release to production"
+20260420-launch_cli
+20260420-verify_on_staging
+20260420-release_to_production
+```
+
 ---
 
 ## 5. Reflect
@@ -612,6 +651,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd organize move ID KIND` | Change item category |
 | `htd organize link ID --project PID` | Link item to a project |
 | `htd organize schedule ID` | Set dates on an item |
+| `htd organize promote ID --child TITLE...` | Promote to a project with next-action children |
 | `htd reflect next-actions` | List active next actions |
 | `htd reflect projects` | List active projects |
 | `htd reflect waiting` | List waiting-for items |

--- a/internal/command/capture.go
+++ b/internal/command/capture.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/takai/htd/internal/id"
 	"github.com/takai/htd/internal/model"
 	"github.com/takai/htd/internal/store"
 )
@@ -69,18 +68,3 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 	return cmd
 }
 
-// generateUniqueID generates an ID and appends a suffix if a collision exists.
-func generateUniqueID(c *container, title string, now time.Time) string {
-	base := id.Generate(title, now)
-	candidate := base
-	for i := 2; ; i++ {
-		path := store.PathForItem(c.cfg, &model.Item{ID: candidate, Kind: model.KindInbox, Status: model.StatusActive})
-		if _, err := store.FindItem(c.cfg, candidate); err != nil && store.IsNotFound(err) {
-			// Also check that the computed path doesn't exist (covers all kinds)
-			_ = path
-			break
-		}
-		candidate = fmt.Sprintf("%s_%d", base, i)
-	}
-	return candidate
-}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -299,6 +299,192 @@ func TestOrganizeSchedule(t *testing.T) {
 	}
 }
 
+func TestOrganizePromote(t *testing.T) {
+	dir := setupDir(t)
+	parent := nowItem("20260420-launch_cli", model.KindInbox, model.StatusActive)
+	parent.Title = "Launch CLI"
+	writeItem(t, dir, parent, "")
+
+	out, _, err := runCmd(t, dir, "organize", "promote", "20260420-launch_cli",
+		"--child", "Verify on staging",
+		"--child", "Release to production",
+	)
+	if err != nil {
+		t.Fatalf("organize promote: %v", err)
+	}
+
+	gotParent, _ := readItem(t, dir, "20260420-launch_cli")
+	if gotParent.Kind != model.KindProject {
+		t.Errorf("parent kind: want project, got %q", gotParent.Kind)
+	}
+	if gotParent.Status != model.StatusActive {
+		t.Errorf("parent status: want active, got %q", gotParent.Status)
+	}
+	cfg := config.New(dir)
+	projectPath := filepath.Join(cfg.DirForKind(model.KindProject), "20260420-launch_cli.md")
+	if _, err := os.Stat(projectPath); err != nil {
+		t.Errorf("parent not moved to project dir: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 output lines (parent + 2 children), got %d: %q", len(lines), out)
+	}
+	if lines[0] != "20260420-launch_cli" {
+		t.Errorf("line 0: want parent ID, got %q", lines[0])
+	}
+	childIDs := []string{lines[1], lines[2]}
+
+	today := time.Now().Format("20060102")
+	wantSuffixes := []string{"-verify_on_staging", "-release_to_production"}
+	for i, id := range childIDs {
+		if !strings.HasPrefix(id, today+"-") {
+			t.Errorf("child %d ID %q should start with today's date", i, id)
+		}
+		if !strings.HasSuffix(id, wantSuffixes[i]) {
+			t.Errorf("child %d ID %q should end with %q", i, id, wantSuffixes[i])
+		}
+		child, _ := readItem(t, dir, id)
+		if child.Kind != model.KindNextAction {
+			t.Errorf("child %s kind: want next_action, got %q", id, child.Kind)
+		}
+		if child.Status != model.StatusActive {
+			t.Errorf("child %s status: want active, got %q", id, child.Status)
+		}
+		if child.Project != "20260420-launch_cli" {
+			t.Errorf("child %s project: want parent ID, got %q", id, child.Project)
+		}
+	}
+	if childIDs[0] == childIDs[1] {
+		t.Errorf("expected distinct child IDs, got duplicate %q", childIDs[0])
+	}
+}
+
+func TestOrganizePromoteParentNotFound(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "organize", "promote", "20260420-ghost", "--child", "X")
+	if !store.IsNotFound(err) {
+		t.Errorf("expected NotFoundError, got %v", err)
+	}
+}
+
+func TestOrganizePromoteParentTerminal(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260420-done_parent", model.KindNextAction, model.StatusDone), "")
+
+	_, _, err := runCmd(t, dir, "organize", "promote", "20260420-done_parent", "--child", "X")
+	if err == nil {
+		t.Error("expected error when promoting a terminal item")
+	}
+}
+
+func TestOrganizePromoteAlreadyProject(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260420-existing_proj", model.KindProject, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "organize", "promote", "20260420-existing_proj", "--child", "Next step")
+	if err != nil {
+		t.Fatalf("organize promote: %v", err)
+	}
+
+	gotParent, _ := readItem(t, dir, "20260420-existing_proj")
+	if gotParent.Kind != model.KindProject {
+		t.Errorf("parent kind: want project, got %q", gotParent.Kind)
+	}
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 output lines, got %d: %q", len(lines), out)
+	}
+	child, _ := readItem(t, dir, lines[1])
+	if child.Project != "20260420-existing_proj" {
+		t.Errorf("child project: want parent ID, got %q", child.Project)
+	}
+}
+
+func TestOrganizePromoteFromNextAction(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260420-was_na", model.KindNextAction, model.StatusActive), "")
+
+	_, _, err := runCmd(t, dir, "organize", "promote", "20260420-was_na", "--child", "First step")
+	if err != nil {
+		t.Fatalf("organize promote: %v", err)
+	}
+	got, _ := readItem(t, dir, "20260420-was_na")
+	if got.Kind != model.KindProject {
+		t.Errorf("kind: want project, got %q", got.Kind)
+	}
+}
+
+func TestOrganizePromoteRequiresChild(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260420-no_kids", model.KindInbox, model.StatusActive), "")
+
+	_, _, err := runCmd(t, dir, "organize", "promote", "20260420-no_kids")
+	if err == nil {
+		t.Error("expected error when --child is omitted")
+	}
+}
+
+func TestOrganizePromoteEmptyChildTitle(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260420-empty_kid", model.KindInbox, model.StatusActive), "")
+
+	_, _, err := runCmd(t, dir, "organize", "promote", "20260420-empty_kid", "--child", "")
+	if err == nil {
+		t.Error("expected error when --child title is empty")
+	}
+}
+
+func TestOrganizePromoteChildIDCollision(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260420-parent", model.KindInbox, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "organize", "promote", "20260420-parent",
+		"--child", "Same Title",
+		"--child", "Same Title",
+	)
+	if err != nil {
+		t.Fatalf("organize promote: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 lines, got %d: %q", len(lines), out)
+	}
+	if lines[1] == lines[2] {
+		t.Errorf("children must have distinct IDs, got duplicate %q", lines[1])
+	}
+	if !strings.HasSuffix(lines[2], "_2") {
+		t.Errorf("second colliding child should end with _2, got %q", lines[2])
+	}
+}
+
+func TestOrganizePromoteJSON(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260420-json_parent", model.KindInbox, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "--json", "organize", "promote", "20260420-json_parent",
+		"--child", "Alpha",
+		"--child", "Beta",
+	)
+	if err != nil {
+		t.Fatalf("organize promote --json: %v", err)
+	}
+	var obj struct {
+		Parent   string   `json:"parent"`
+		Children []string `json:"children"`
+	}
+	if err := json.Unmarshal([]byte(out), &obj); err != nil {
+		t.Fatalf("parse json: %v (out=%q)", err, out)
+	}
+	if obj.Parent != "20260420-json_parent" {
+		t.Errorf("parent: want %q, got %q", "20260420-json_parent", obj.Parent)
+	}
+	if len(obj.Children) != 2 {
+		t.Fatalf("children: want 2, got %d", len(obj.Children))
+	}
+}
+
 // ---------- engage ----------
 
 func TestEngageDone(t *testing.T) {

--- a/internal/command/helpers.go
+++ b/internal/command/helpers.go
@@ -1,0 +1,24 @@
+package command
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/takai/htd/internal/id"
+	"github.com/takai/htd/internal/store"
+)
+
+// generateUniqueID returns an ID derived from title at time now, appending a
+// numeric suffix (_2, _3, ...) when the base ID already exists anywhere on
+// disk (any kind directory or the archive).
+func generateUniqueID(c *container, title string, now time.Time) string {
+	base := id.Generate(title, now)
+	candidate := base
+	for i := 2; ; i++ {
+		if _, err := store.FindItem(c.cfg, candidate); err != nil && store.IsNotFound(err) {
+			break
+		}
+		candidate = fmt.Sprintf("%s_%d", base, i)
+	}
+	return candidate
+}

--- a/internal/command/organize.go
+++ b/internal/command/organize.go
@@ -20,6 +20,7 @@ func newOrganizeCommand(c *container) *cobra.Command {
 		newOrganizeMoveCommand(c),
 		newOrganizeLinkCommand(c),
 		newOrganizeScheduleCommand(c),
+		newOrganizePromoteCommand(c),
 	)
 	return cmd
 }
@@ -184,4 +185,79 @@ func parseDate(s string) (*time.Time, error) {
 
 func isValidKind(k model.Kind) bool {
 	return slices.Contains(model.ValidKinds(), k)
+}
+
+func newOrganizePromoteCommand(c *container) *cobra.Command {
+	var children []string
+
+	cmd := &cobra.Command{
+		Use:   "promote ID",
+		Short: "Promote an item to a project and create linked next-action children",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(children) == 0 {
+				return fmt.Errorf("at least one --child is required")
+			}
+			for _, title := range children {
+				if title == "" {
+					return fmt.Errorf("--child title must not be empty")
+				}
+			}
+
+			parentID := args[0]
+			parentPath, err := store.FindItem(c.cfg, parentID)
+			if err != nil {
+				return err
+			}
+			parent, parentBody, err := store.Read(parentPath)
+			if err != nil {
+				return err
+			}
+			if !model.IsActive(parent.Status) {
+				return fmt.Errorf("cannot promote item with status %q", parent.Status)
+			}
+
+			now := time.Now()
+
+			if parent.Kind != model.KindProject {
+				parent.Kind = model.KindProject
+				parent.UpdatedAt = now
+				newPath := store.PathForItem(c.cfg, parent)
+				if parentPath == newPath {
+					if err := store.Write(parentPath, parent, parentBody); err != nil {
+						return err
+					}
+				} else {
+					if err := store.Move(parentPath, newPath, parent, parentBody); err != nil {
+						return err
+					}
+				}
+			}
+
+			childIDs := make([]string, 0, len(children))
+			for _, title := range children {
+				childID := generateUniqueID(c, title, now)
+				child := &model.Item{
+					ID:        childID,
+					Title:     title,
+					Kind:      model.KindNextAction,
+					Status:    model.StatusActive,
+					Project:   parent.ID,
+					CreatedAt: now,
+					UpdatedAt: now,
+				}
+				childPath := store.PathForItem(c.cfg, child)
+				if err := store.Write(childPath, child, ""); err != nil {
+					return err
+				}
+				childIDs = append(childIDs, childID)
+			}
+
+			c.printer.PrintPromote(parent.ID, childIDs)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&children, "child", nil, "Child next-action title (repeatable; at least one required)")
+	return cmd
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -30,6 +30,24 @@ func (p *Printer) PrintID(id string) {
 	fmt.Fprintln(p.out, id)
 }
 
+// PrintPromote prints the result of `organize promote`: the parent ID followed
+// by each child ID, one per line. In JSON mode, emits a single object of shape
+// {"parent": "...", "children": [...]}.
+func (p *Printer) PrintPromote(parent string, children []string) {
+	if p.json {
+		data, _ := json.Marshal(struct {
+			Parent   string   `json:"parent"`
+			Children []string `json:"children"`
+		}{Parent: parent, Children: children})
+		fmt.Fprintln(p.out, string(data))
+		return
+	}
+	fmt.Fprintln(p.out, parent)
+	for _, id := range children {
+		fmt.Fprintln(p.out, id)
+	}
+}
+
 func (p *Printer) PrintPaths(paths []string) {
 	if p.json {
 		data, _ := json.Marshal(paths)

--- a/plugins/htd/agents/clarify.md
+++ b/plugins/htd/agents/clarify.md
@@ -31,7 +31,7 @@ You run the Clarify phase of the htd workflow. Your job is to turn every inbox i
       - Yes → continue.
 
    b. **Does it need more than one action?**
-      - Yes → it's a project: `htd organize move <id> project`. Ask: "What's the first next action for this project?" and help the user capture and link it via `/htd:capture`-like flow, then `htd organize link <new-na-id> --project <id>`.
+      - Yes → it's a project. Ask: "What are the first next actions for this project?" (one or more short titles) and run `htd organize promote <id> --child "<title 1>" [--child "<title 2>"]...` in a single command. This promotes the parent to `project`, creates each child as `next_action`, and links them all in one shot. If the user can't name any children yet, fall back to `htd organize move <id> project` alone and revisit later.
       - No → continue.
 
    c. **Am I the one doing it?**

--- a/plugins/htd/commands/organize.md
+++ b/plugins/htd/commands/organize.md
@@ -24,7 +24,7 @@ If `$ARGUMENTS` is empty, ask which item they want to organize (offer to show `h
 
 3. Propose organization changes based on the title and body. Ask the user about each dimension that could be set, but skip ones that are already reasonable. For each proposal, show the exact `htd` command and wait for confirmation before running.
 
-   - **Kind** — if it's still `inbox` or the wrong kind, suggest one of next_action / project / waiting_for / someday / tickler and run `htd organize move <id> <kind>`. Cannot target `inbox`.
+   - **Kind** — if it's still `inbox` or the wrong kind, suggest one of next_action / project / waiting_for / someday / tickler and run `htd organize move <id> <kind>`. Cannot target `inbox`. If the item clearly needs to become a project with obvious first sub-actions, prefer `htd organize promote <id> --child "<title 1>" [--child "<title 2>"]...` to promote and seed children in one shot.
    - **Project link** — if the item looks related to an existing project, suggest it. To find candidates: `htd item list --kind project --status active --json`. Run `htd organize link <id> --project <project-id>` to link, or `--project ""` to clear.
    - **Dates** — if the user mentions timing ("next week", "by Friday", "defer until the 15th"), convert to `YYYY-MM-DD` and run `htd organize schedule <id> [--due …] [--defer …] [--review …]`. Pass `""` to clear a date.
    - **Tags** — if the user wants to tag: `htd item update <id> tags='[a,b]'`.

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -61,6 +61,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 - `htd organize move ID KIND` — KIND ∈ {next_action, project, waiting_for, someday, tickler}; cannot target `inbox`.
 - `htd organize link ID --project PROJECT_ID` — empty string to unlink.
 - `htd organize schedule ID [--due DATE] [--defer DATE] [--review DATE]` — empty string to clear. Dates accept `YYYY-MM-DD` or RFC 3339.
+- `htd organize promote ID --child TITLE [--child TITLE]...` — one-shot promote an item to a project and create linked next-action children. Prefer this over the move+capture+link chain when clarifying an item that clearly needs sub-actions.
 
 **Reflect** (review the system)
 - `htd reflect next-actions` — all active next actions, deferred hidden.


### PR DESCRIPTION
## Summary

Adds `htd organize promote ID --child TITLE...`, collapsing the ~7-command move+capture+link chain for promoting an inbox item into a project with sub-next-actions into a single invocation.

- Parent: any active item; moved to `kind: project` (no-op if already one).
- Children: each `--child TITLE` is created as an active `next_action` linked to the parent via the `project` field. ID collisions between same-titled siblings are resolved with the existing `_2`, `_3` suffix rule.
- Output: parent ID followed by child IDs, one per line. `--json` emits `{"parent": "...", "children": [...]}`.

Docs (`docs/cli.md` §4.4 + summary table) and the plugin (skill cheat sheet, `clarify` agent step 3b, `/htd:organize` command) are updated so the plugin recommends `promote` for the common "project with initial next actions" clarify outcome.

Closes #2.

## Test plan

- [x] `go test ./...` passes.
- [x] `golangci-lint run ./...` clean.
- [ ] Manual smoke: promote an inbox item with two children; verify parent moves to `items/project/`, children land under `items/next_action/` with the parent's ID in `project:`, and both text and `--json` output match the spec.