### PR TITLE
feat(capture): add --done flag

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,7 +65,7 @@ Resolution order for the root directory: `--path` (if given) → `$HTD_PATH` (if
 Add a new item to the inbox.
 
 ```
-htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]...
+htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]... [--done]
 ```
 
 | Option | Required | Description |
@@ -74,6 +74,7 @@ htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]...
 | `--body` | no | Detailed description (Markdown) |
 | `--source` | no | Origin of the item (e.g., `email`, `meeting`, `slack`) |
 | `--tag` | no | Tag to attach; repeatable for multiple tags |
+| `--done` | no | Capture the item as already completed (see below) |
 
 **Behavior:**
 
@@ -88,6 +89,25 @@ htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]...
 ```
 $ htd capture add --title "Write the man page" --source manual --tag cli --tag docs
 20260417-write_the_man_page
+```
+
+**`--done` behavior:**
+
+When `--done` is passed, the item is captured as already completed instead of entering the inbox. This is a shortcut for items that were completed on the spot — a single action whose capture and completion collapse into the same step.
+
+1. Generate a new ID (same rule as above).
+2. Set `kind: next_action`, `status: done`.
+3. Set `created_at` and `updated_at` to the current timestamp.
+4. Write the file directly to `archive/items/<id>.md` (no temporary stop in `items/inbox/`).
+5. Print the created ID to stdout.
+
+`--body`, `--source`, and `--tag` still apply when `--done` is set, so metadata is preserved on the archived item.
+
+**Example:**
+
+```
+$ htd capture add --title "Reply to Alice" --done
+20260420-reply_to_alice
 ```
 
 ---

--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -65,6 +65,7 @@ stateDiagram-v2
     direction TB
 
     [*] --> inbox : capture add
+    [*] --> done  : capture add --done
 
     state "active" as active {
         inbox
@@ -119,6 +120,7 @@ stateDiagram-v2
 
 - `organize move` changes an item's kind within the `active` state; it does not affect status.
 - `discarded` is only reachable from `inbox` via `clarify discard`.
+- `capture add --done` bypasses the inbox entirely: the item is born with `kind: next_action`, `status: done`, and is written directly to `archive/items/`. This is not a violation of the "inbox items cannot go directly to done" rule because the item never has `kind: inbox` at any point.
 - All terminal transitions are one-way. Items cannot return to `active` (use `htd item update` for error correction only).
 
 ---

--- a/internal/command/capture.go
+++ b/internal/command/capture.go
@@ -25,6 +25,7 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 		body   string
 		source string
 		tags   []string
+		done   bool
 	)
 
 	cmd := &cobra.Command{
@@ -37,11 +38,21 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 			now := time.Now()
 			itemID := generateUniqueID(c, title, now)
 
+			kind := model.KindInbox
+			status := model.StatusActive
+			if done {
+				// --done lands the item directly as a completed next_action,
+				// bypassing the inbox. The item is routed to archive/items/
+				// by store.PathForItem because its status is terminal.
+				kind = model.KindNextAction
+				status = model.StatusDone
+			}
+
 			item := &model.Item{
 				ID:        itemID,
 				Title:     title,
-				Kind:      model.KindInbox,
-				Status:    model.StatusActive,
+				Kind:      kind,
+				Status:    status,
 				Source:    source,
 				Tags:      tags,
 				CreatedAt: now,
@@ -64,6 +75,7 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 	cmd.Flags().StringVar(&body, "body", "", "Detailed description (Markdown)")
 	cmd.Flags().StringVar(&source, "source", "", "Origin of the item")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable)")
+	cmd.Flags().BoolVar(&done, "done", false, "Capture the item as already completed (lands in archive/items/ with kind=next_action, status=done)")
 
 	return cmd
 }

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -121,6 +121,61 @@ func TestCaptureAddWithOptions(t *testing.T) {
 	}
 }
 
+func TestCaptureAddDone(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "capture", "add", "--title", "Quick thing", "--done")
+	if err != nil {
+		t.Fatalf("capture add --done: %v", err)
+	}
+	id := strings.TrimSpace(out)
+	if id == "" {
+		t.Fatal("expected ID output")
+	}
+
+	cfg := config.New(dir)
+	archivePath := filepath.Join(cfg.ArchiveItemsDir(), id+".md")
+	if _, err := os.Stat(archivePath); err != nil {
+		t.Fatalf("expected item at %q, stat err: %v", archivePath, err)
+	}
+	inboxPath := filepath.Join(cfg.DirForKind(model.KindInbox), id+".md")
+	if _, err := os.Stat(inboxPath); !os.IsNotExist(err) {
+		t.Errorf("expected no item at %q; stat err: %v", inboxPath, err)
+	}
+
+	item, _ := readItem(t, dir, id)
+	if item.Kind != model.KindNextAction {
+		t.Errorf("kind: want next_action, got %q", item.Kind)
+	}
+	if item.Status != model.StatusDone {
+		t.Errorf("status: want done, got %q", item.Status)
+	}
+}
+
+func TestCaptureAddDonePreservesMetadata(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "capture", "add",
+		"--title", "Quick thing with detail",
+		"--body", "body text",
+		"--source", "manual",
+		"--tag", "quick",
+		"--done",
+	)
+	if err != nil {
+		t.Fatalf("capture add --done: %v", err)
+	}
+	id := strings.TrimSpace(out)
+	item, body := readItem(t, dir, id)
+	if item.Source != "manual" {
+		t.Errorf("source: want manual, got %q", item.Source)
+	}
+	if len(item.Tags) != 1 || item.Tags[0] != "quick" {
+		t.Errorf("tags: want [quick], got %v", item.Tags)
+	}
+	if body != "body text" {
+		t.Errorf("body: want %q, got %q", "body text", body)
+	}
+}
+
 func TestCaptureAddIDFormat(t *testing.T) {
 	dir := setupDir(t)
 	out, _, err := runCmd(t, dir, "capture", "add", "--title", "Write the man page")

--- a/plugins/htd/commands/capture.md
+++ b/plugins/htd/commands/capture.md
@@ -35,10 +35,20 @@ htd capture add --title "<title>" [--body "<body>"] [--source <source>] [--tag <
 
 Run it, print the resulting ID, and stop. Do not chain into clarify/organize — the user will do that later with `/htd:clarify` or `/htd:organize`.
 
+## Already-done shortcut
+
+If the user reports that they just finished something quick ("I just did X", "done: X", "already handled X"), pass `--done` to capture it as completed in one step:
+
+```bash
+htd capture add --title "<title>" --done
+```
+
+This lands the item directly in `archive/items/` with `kind: next_action`, `status: done` — no stop in the inbox, no follow-up `engage done` needed. `--body`, `--source`, and `--tag` still apply. Prefer this over `capture add` + `engage done <id>` for anything the user has already completed.
+
 ## Notes
 
 - Titles stay in English per project convention.
 - Keep titles concise — aim for roughly 6–8 words and under 50 characters. The ID is derived from the title as `YYYYMMDD-<slug>`, and long IDs clutter list output and shell history. Trim filler words, drop redundant context (repo names, ticket numbers beyond the primary one), and save details for `--body`.
 - The ID is auto-generated from the title. Don't try to set it yourself.
-- The item lands in `items/inbox/` with `kind: inbox`, `status: active`.
+- Without `--done`, the item lands in `items/inbox/` with `kind: inbox`, `status: active`. With `--done`, it lands in `archive/items/` with `kind: next_action`, `status: done`.
 - If `$ARGUMENTS` would produce an empty title (whitespace only), fall through to the "arguments empty" path.

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -50,6 +50,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 
 **Capture**
 - `htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]...`
+- `htd capture add --title TEXT --done [--body TEXT] [--source NAME] [--tag TAG]...` — capture an already-completed item. Bypasses the inbox; the item lands directly in `archive/items/` with `kind: next_action`, `status: done`. Prefer this over `capture add` followed by `engage done <id>` when the user has already finished the task.
 
 **Clarify** (inbox only)
 - `htd clarify list`
@@ -88,6 +89,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 | User says / situation | Suggest |
 |-----------------------|---------|
 | "remember to X", "I just thought of X", a random idea | `htd capture add` or `/htd:capture` |
+| "I just did X", "already handled X", a small task already completed | `htd capture add --title "X" --done` |
 | "my inbox is full", "process my inbox" | `/htd:clarify` (walks item-by-item) |
 | "categorize this", "link this to project Y", "set a due date" | `/htd:organize` |
 | "weekly review", "how's my system looking", "what's stalled" | `/htd:reflect` |


### PR DESCRIPTION
## Summary

Adds `htd capture add --done` — captures an item as already completed, bypassing the inbox. The item is written directly to `archive/items/` with `kind: next_action`, `status: done`, collapsing the former `capture add` + `engage done <id>` pair into a single command.

- `--body`, `--source`, and `--tag` still apply when `--done` is set, so metadata is preserved on the archived item.
- The item never has `kind: inbox` at any point, so the "inbox items cannot go directly to done" invariant is untouched. This is called out in `docs/datamodel.md` §2.4 alongside an added `[*] --> done : capture add --done` transition in the state diagram.
- Plugin updated: cheat sheet entry in the workflow skill, "I just did X" row in the command-picker table, and a new "already-done shortcut" section in `/htd:capture` so agents reach for this over the two-step sequence.

Closes #3.

## Test plan

- [x] `go test ./...` passes (new `TestCaptureAddDone` and `TestCaptureAddDonePreservesMetadata`).
- [x] `golangci-lint run ./...` clean.
- [ ] Manual smoke: `htd capture add --title "Quick thing" --done` lands the file under `archive/items/` with the expected front matter and prints the ID.
- [ ] Manual smoke: `--done` with `--body`/`--source`/`--tag` preserves all metadata on the archived item.