### PR TITLE
docs: add PR workflow guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,18 @@ Headless To-Do (htd) is a headless task management system that enables both AI a
 
 ## Build Commands
 
-- n/a
+- `mise run build` — build the binary.
+- `mise run test` — run the full test suit.
+- `mise run lint` — run lint.
 
 ## Development Guidelines
 
 - Use the red/green/refactor TDD cycle.
 - Use `git ai-commit` to create commits.
   - Always include a short, clear summary in English using the `--context` option.
+
+## Pull Request Workflow
+
+1. Always work on a feature branch.
+2. Update the documentation alongside the code.
+3. Close the original issue via the PR.


### PR DESCRIPTION
## Summary

Codifies three rules that have come up repeatedly while handing issues off to Claude:

1. Always work on a feature branch; never commit directly on `main`.
2. Ship documentation (`docs/`) and plugin (`plugins/htd/`) updates in the same PR as the code change so the plugin's guidance stays in sync with the binary.
3. Include `Closes #<issue-number>` in the PR body so the original issue auto-closes on merge.

No code changes.

## Test plan

- [x] No runtime impact — docs-only change.