### PR TITLE
feat(reflect): rename done to log with kind/tag/status filters

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -371,24 +371,42 @@ htd reflect review
 3. Display: `ID`, `TITLE`, `KIND`, `REVIEW_AT`.
 4. Sort by `review_at` ascending.
 
-### 5.5 `htd reflect done`
+### 5.5 `htd reflect log`
 
-List recently completed items.
+List recently resolved items — an activity log for daily standups, weekly reviews, and retros.
 
 ```
-htd reflect done --since DATE
+htd reflect log --since DATE [--until DATE] [--kind KIND] [--tag TAG]... [--status STATUS]...
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `--since` | yes | Show items completed since this date (`YYYY-MM-DD`) |
+| `--since` | yes | Show items updated on or after this date (`YYYY-MM-DD`) |
+| `--until` | no | Show items updated on or before this date (`YYYY-MM-DD`); inclusive end-of-day |
+| `--kind` | no | Filter by kind |
+| `--tag` | no | Filter by tag; repeatable (items must match all supplied tags) |
+| `--status` | no | Filter by terminal status; repeatable. Values: `done`, `canceled`, `discarded`, `archived`. Defaults to `done` when omitted. |
 
 **Behavior:**
 
-1. Read all files in `archive/items/` with `status: done`.
-2. Filter to items where `updated_at >= --since`.
-3. Display: `ID`, `TITLE`, `KIND`, `UPDATED_AT`.
-4. Sort by `updated_at` descending.
+1. Read all files in `archive/items/` matching the status filter.
+2. Filter to items where `updated_at >= --since` (and `<= --until` if given).
+3. Apply `--kind` and `--tag` filters.
+4. Display: `ID`, `KIND`, `STATUS`, `UPDATED_AT`, `TITLE`.
+5. Sort by `updated_at` descending.
+
+**Examples:**
+
+```
+# What did I finish today?
+$ htd reflect log --since 2026-04-20
+
+# Weekly wrap-up, including canceled items
+$ htd reflect log --since 2026-04-14 --status done --status canceled
+
+# What docs-tagged next actions closed this month?
+$ htd reflect log --since 2026-04-01 --kind next_action --tag docs
+```
 
 ---
 
@@ -676,7 +694,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd reflect projects` | List active projects |
 | `htd reflect waiting` | List waiting-for items |
 | `htd reflect review` | List items due for review |
-| `htd reflect done --since DATE` | List recently completed items |
+| `htd reflect log --since DATE` | List recently resolved items (activity log) |
 | `htd engage done ID` | Mark an item as done |
 | `htd engage cancel ID` | Cancel an active item |
 | `htd engage next-action` | List next actions ready to work on now |

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -998,17 +998,122 @@ func TestReflectWaiting(t *testing.T) {
 	}
 }
 
-func TestReflectDone(t *testing.T) {
+func TestReflectLogDefault(t *testing.T) {
 	dir := setupDir(t)
-	item := nowItem("20260417-done_item", model.KindNextAction, model.StatusDone)
-	writeItem(t, dir, item, "")
+	done := nowItem("20260417-log_done", model.KindNextAction, model.StatusDone)
+	canceled := nowItem("20260417-log_canceled", model.KindNextAction, model.StatusCanceled)
+	writeItem(t, dir, done, "")
+	writeItem(t, dir, canceled, "")
 
-	out, _, err := runCmd(t, dir, "reflect", "done", "--since", "2026-01-01")
+	out, _, err := runCmd(t, dir, "reflect", "log", "--since", "2026-01-01")
 	if err != nil {
-		t.Fatalf("reflect done: %v", err)
+		t.Fatalf("reflect log: %v", err)
 	}
-	if !strings.Contains(out, "20260417-done_item") {
+	if !strings.Contains(out, "20260417-log_done") {
 		t.Errorf("missing done item: %q", out)
+	}
+	if strings.Contains(out, "20260417-log_canceled") {
+		t.Errorf("default status filter should exclude canceled: %q", out)
+	}
+	if !strings.Contains(out, "UPDATED_AT") {
+		t.Errorf("log output should include UPDATED_AT header: %q", out)
+	}
+}
+
+func TestReflectLogKindFilter(t *testing.T) {
+	dir := setupDir(t)
+	na := nowItem("20260417-log_na", model.KindNextAction, model.StatusDone)
+	proj := nowItem("20260417-log_proj", model.KindProject, model.StatusDone)
+	writeItem(t, dir, na, "")
+	writeItem(t, dir, proj, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "log",
+		"--since", "2026-01-01", "--kind", "project")
+	if err != nil {
+		t.Fatalf("reflect log --kind: %v", err)
+	}
+	if !strings.Contains(out, "20260417-log_proj") {
+		t.Errorf("missing project item: %q", out)
+	}
+	if strings.Contains(out, "20260417-log_na") {
+		t.Errorf("kind filter should exclude next_action: %q", out)
+	}
+}
+
+func TestReflectLogTagFilter(t *testing.T) {
+	dir := setupDir(t)
+	tagged := nowItem("20260417-log_tagged", model.KindNextAction, model.StatusDone)
+	tagged.Tags = []string{"cli", "docs"}
+	other := nowItem("20260417-log_other", model.KindNextAction, model.StatusDone)
+	other.Tags = []string{"cli"}
+	writeItem(t, dir, tagged, "")
+	writeItem(t, dir, other, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "log",
+		"--since", "2026-01-01", "--tag", "cli", "--tag", "docs")
+	if err != nil {
+		t.Fatalf("reflect log --tag: %v", err)
+	}
+	if !strings.Contains(out, "20260417-log_tagged") {
+		t.Errorf("missing all-tags match: %q", out)
+	}
+	if strings.Contains(out, "20260417-log_other") {
+		t.Errorf("partial tag match should be excluded: %q", out)
+	}
+}
+
+func TestReflectLogStatusMulti(t *testing.T) {
+	dir := setupDir(t)
+	done := nowItem("20260417-log_d", model.KindNextAction, model.StatusDone)
+	canceled := nowItem("20260417-log_c", model.KindNextAction, model.StatusCanceled)
+	archived := nowItem("20260417-log_a", model.KindNextAction, model.StatusArchived)
+	writeItem(t, dir, done, "")
+	writeItem(t, dir, canceled, "")
+	writeItem(t, dir, archived, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "log",
+		"--since", "2026-01-01",
+		"--status", "done", "--status", "canceled")
+	if err != nil {
+		t.Fatalf("reflect log --status: %v", err)
+	}
+	if !strings.Contains(out, "20260417-log_d") || !strings.Contains(out, "20260417-log_c") {
+		t.Errorf("multi-status should include done and canceled: %q", out)
+	}
+	if strings.Contains(out, "20260417-log_a") {
+		t.Errorf("archived should be excluded: %q", out)
+	}
+}
+
+func TestReflectLogSinceBoundary(t *testing.T) {
+	dir := setupDir(t)
+	old := &model.Item{
+		ID: "20260101-old_done", Title: "old", Kind: model.KindNextAction, Status: model.StatusDone,
+		CreatedAt: time.Date(2026, 1, 1, 9, 0, 0, 0, time.Local),
+		UpdatedAt: time.Date(2026, 1, 1, 9, 0, 0, 0, time.Local),
+	}
+	recent := nowItem("20260417-recent_done", model.KindNextAction, model.StatusDone)
+	writeItem(t, dir, old, "")
+	writeItem(t, dir, recent, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "log", "--since", "2026-04-01")
+	if err != nil {
+		t.Fatalf("reflect log --since: %v", err)
+	}
+	if !strings.Contains(out, "20260417-recent_done") {
+		t.Errorf("recent item should be included: %q", out)
+	}
+	if strings.Contains(out, "20260101-old_done") {
+		t.Errorf("item before --since should be excluded: %q", out)
+	}
+}
+
+func TestReflectLogInvalidStatus(t *testing.T) {
+	dir := setupDir(t)
+	_, stderr, err := runCmd(t, dir, "reflect", "log",
+		"--since", "2026-01-01", "--status", "active")
+	if err == nil {
+		t.Fatalf("expected error for non-terminal status, got nil; stderr=%q", stderr)
 	}
 }
 

--- a/internal/command/organize.go
+++ b/internal/command/organize.go
@@ -198,10 +198,8 @@ func newOrganizePromoteCommand(c *container) *cobra.Command {
 			if len(children) == 0 {
 				return fmt.Errorf("at least one --child is required")
 			}
-			for _, title := range children {
-				if title == "" {
-					return fmt.Errorf("--child title must not be empty")
-				}
+			if slices.Contains(children, "") {
+				return fmt.Errorf("--child title must not be empty")
 			}
 
 			parentID := args[0]

--- a/internal/command/reflect.go
+++ b/internal/command/reflect.go
@@ -21,7 +21,7 @@ func newReflectCommand(c *container) *cobra.Command {
 		newReflectProjectsCommand(c),
 		newReflectWaitingCommand(c),
 		newReflectReviewCommand(c),
-		newReflectDoneCommand(c),
+		newReflectLogCommand(c),
 	)
 	return cmd
 }
@@ -148,38 +148,101 @@ func newReflectReviewCommand(c *container) *cobra.Command {
 	}
 }
 
-func newReflectDoneCommand(c *container) *cobra.Command {
-	var since string
+func newReflectLogCommand(c *container) *cobra.Command {
+	var (
+		since    string
+		until    string
+		kindStr  string
+		tags     []string
+		statuses []string
+	)
 
 	cmd := &cobra.Command{
-		Use:   "done",
-		Short: "List recently completed items",
+		Use:   "log",
+		Short: "List recently resolved items (activity log)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			sinceTime, err := time.ParseInLocation("2006-01-02", since, time.Local)
 			if err != nil {
 				return fmt.Errorf("--since: cannot parse %q as date", since)
 			}
 
-			status := model.StatusDone
-			items, err := store.List(c.cfg, store.Filter{Status: &status})
+			var untilEnd time.Time
+			if until != "" {
+				u, err := time.ParseInLocation("2006-01-02", until, time.Local)
+				if err != nil {
+					return fmt.Errorf("--until: cannot parse %q as date", until)
+				}
+				untilEnd = time.Date(u.Year(), u.Month(), u.Day(), 23, 59, 59, 0, u.Location())
+			}
+
+			statusSet, err := parseLogStatuses(statuses)
 			if err != nil {
 				return err
 			}
+
+			f := store.Filter{}
+			if kindStr != "" {
+				k := model.Kind(kindStr)
+				if !isValidKind(k) {
+					return fmt.Errorf("invalid kind %q", kindStr)
+				}
+				f.Kind = &k
+			}
+			if len(statusSet) == 1 {
+				for s := range statusSet {
+					f.Status = &s
+				}
+			}
+
+			items, err := store.List(c.cfg, f)
+			if err != nil {
+				return err
+			}
+
 			var result []*model.Item
 			for _, it := range items {
-				if !it.UpdatedAt.Before(sinceTime) {
-					result = append(result, it)
+				if _, ok := statusSet[it.Status]; !ok {
+					continue
 				}
+				if it.UpdatedAt.Before(sinceTime) {
+					continue
+				}
+				if !untilEnd.IsZero() && it.UpdatedAt.After(untilEnd) {
+					continue
+				}
+				if !matchAllTags(it, tags) {
+					continue
+				}
+				result = append(result, it)
 			}
 			sort.Slice(result, func(i, j int) bool {
 				return result[i].UpdatedAt.After(result[j].UpdatedAt)
 			})
-			c.printer.PrintItems(result)
+			c.printer.PrintLogItems(result)
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&since, "since", "", "Show items completed since this date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&since, "since", "", "Show items updated on or after this date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&until, "until", "", "Show items updated on or before this date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&kindStr, "kind", "", "Filter by kind")
+	cmd.Flags().StringSliceVar(&tags, "tag", nil, "Filter by tag (repeatable)")
+	cmd.Flags().StringSliceVar(&statuses, "status", nil, "Filter by terminal status (repeatable; default: done)")
 	_ = cmd.MarkFlagRequired("since")
 	return cmd
+}
+
+func parseLogStatuses(raw []string) (map[model.Status]struct{}, error) {
+	if len(raw) == 0 {
+		return map[model.Status]struct{}{model.StatusDone: {}}, nil
+	}
+	set := make(map[model.Status]struct{}, len(raw))
+	for _, s := range raw {
+		status := model.Status(s)
+		if !model.IsTerminal(status) {
+			return nil, fmt.Errorf("--status: %q is not a terminal status (done, canceled, discarded, archived)", s)
+		}
+		set[status] = struct{}{}
+	}
+	return set, nil
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -233,6 +233,27 @@ func (p *Printer) printItemsJSON(items []*model.Item) {
 	fmt.Fprintln(p.out, string(data))
 }
 
+// PrintLogItems prints a reflect log view: ID, KIND, STATUS, UPDATED_AT, TITLE.
+// JSON output is the same shape as PrintItems (full item fields).
+func (p *Printer) PrintLogItems(items []*model.Item) {
+	if p.json {
+		p.printItemsJSON(items)
+		return
+	}
+	tw := tabwriter.NewWriter(p.out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tKIND\tSTATUS\tUPDATED_AT\tTITLE")
+	for _, it := range items {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			it.ID,
+			it.Kind,
+			it.Status,
+			it.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			truncateRunes(it.Title, 40),
+		)
+	}
+	_ = tw.Flush()
+}
+
 type waitingItemJSON struct {
 	itemJSON
 	AgeDays int `json:"age_days"`


### PR DESCRIPTION
## Summary

- Renames `htd reflect done` → `htd reflect log` to better match its purpose as an activity log (daily standups, weekly reviews, retros).
- Adds `--kind`, `--tag` (repeatable), `--status` (repeatable), and `--until` filters alongside the existing `--since`. Default `--status` is `done`; pass e.g. `--status done --status canceled` to broaden.
- Introduces a log-specific output (`ID KIND STATUS UPDATED_AT TITLE`) so the "when" is visible at a glance.

This is a rename, not an alias — pre-1.0, single-user tool. Previous `reflect done` invocations will now return "unknown command".

Closes #4.

## Test plan
- [x] `mise run lint` — 0 issues
- [x] `mise run test` — all packages pass, with new `TestReflectLog*` cases covering default status, `--kind`, `--tag` (all-match), multi `--status`, `--since` boundary, and invalid status.
- [ ] Manual smoke in a fresh `HTD_PATH`:
  - `htd capture add --title "ship it" --done`
  - `htd capture add --title "park this" --tag work` then `htd engage cancel <id>`
  - `htd reflect log --since 2026-04-20` shows only the done item
  - `htd reflect log --since 2026-04-20 --status done --status canceled` shows both
  - `htd reflect log --since 2026-04-20 --tag work --status canceled` shows only the canceled one