### PR TITLE
feat(reflect): surface fired ticklers via tickler --pull + daily-review

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -408,6 +408,50 @@ $ htd reflect log --since 2026-04-14 --status done --status canceled
 $ htd reflect log --since 2026-04-01 --kind next_action --tag docs
 ```
 
+### 5.6 `htd reflect tickler`
+
+List tickler items whose trigger date has arrived, or pull them into the inbox for re-clarification.
+
+```
+htd reflect tickler [--pull]
+```
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--pull` | no | Move fired tickler items into `items/inbox/` instead of just listing them |
+
+**Behavior:**
+
+1. Read all files in `items/tickler/` with `status: active`.
+2. For each item, take `defer_until` as the trigger; if absent, fall back to `review_at`; if both are absent, skip.
+3. Keep items whose trigger is today or in the past.
+4. Sort by trigger ascending (earliest first).
+5. Without `--pull`: display `ID`, `TITLE`, `DEFER_UNTIL`. No state change.
+6. With `--pull`, for each selected item in trigger order:
+   - Set `kind: inbox`.
+   - Clear `defer_until` (the deferral has served its purpose). `review_at` is preserved.
+   - Set `updated_at` to the current timestamp.
+   - Move the file to `items/inbox/<id>.md`.
+   - Print the moved ID to stdout.
+
+Pulled items land in the inbox as unclarified input, so they flow through the normal `clarify` process — a fired tickler is a prompt to re-decide, not an auto-promotion to `next_action`.
+
+**JSON output:**
+
+- Without `--pull`: array of items.
+- With `--pull`: `{"pulled": ["<id>", ...]}`.
+
+**Examples:**
+
+```
+# See what fired today
+$ htd reflect tickler
+
+# Empty the fired items into the inbox for clarify
+$ htd reflect tickler --pull
+20260417-quarterly_review_prep
+```
+
 ---
 
 ## 6. Engage
@@ -497,22 +541,6 @@ htd engage waiting [--stale-days N]
 5. Sort by age descending (oldest first).
 
 **JSON output:** Array of items with an added `age_days` integer field.
-
-### 6.5 `htd engage tickler`
-
-List tickler items whose trigger date has arrived.
-
-```
-htd engage tickler
-```
-
-**Behavior:**
-
-1. Read all files in `items/tickler/` with `status: active`.
-2. For each item, take `defer_until` as the trigger; if absent, fall back to `review_at`; if both are absent, skip.
-3. Keep items whose trigger is today or in the past.
-4. Display: `ID`, `TITLE`, `DEFER_UNTIL`.
-5. Sort by trigger ascending (earliest first).
 
 ---
 
@@ -695,11 +723,11 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd reflect waiting` | List waiting-for items |
 | `htd reflect review` | List items due for review |
 | `htd reflect log --since DATE` | List recently resolved items (activity log) |
+| `htd reflect tickler [--pull]` | List fired tickler items, or pull them into the inbox |
 | `htd engage done ID` | Mark an item as done |
 | `htd engage cancel ID` | Cancel an active item |
 | `htd engage next-action` | List next actions ready to work on now |
 | `htd engage waiting` | List waiting-for items that need follow-up |
-| `htd engage tickler` | List tickler items whose trigger date has arrived |
 | `htd item get ID` | Get any item by ID |
 | `htd item list` | List items with filters |
 | `htd item update ID` | Update item fields directly |

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -35,8 +35,8 @@ The system structures all task management around five sequential phases:
 | **Capture** | Collect inputs into a single inbox | `htd capture` |
 | **Clarify** | Process inbox items — define, update, or discard | `htd clarify` |
 | **Organize** | Categorize, link to projects, and schedule | `htd organize` |
-| **Reflect** | Review lists, detect stalled projects, check progress | `htd reflect` |
-| **Engage** | Choose and complete work; surface what needs action now (ready next actions, stale waiting-for items, fired ticklers) | `htd engage` |
+| **Reflect** | Review lists, detect stalled projects, empty fired ticklers into the inbox, check progress | `htd reflect` |
+| **Engage** | Choose and complete work; surface what needs action now (ready next actions, stale waiting-for items) | `htd engage` |
 
 ### 2.2 Data Types
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -821,56 +821,6 @@ func TestEngageWaitingJSONIncludesAgeDays(t *testing.T) {
 	}
 }
 
-func TestEngageTickler(t *testing.T) {
-	dir := setupDir(t)
-	now := time.Now()
-	past := now.Add(-24 * time.Hour)
-	future := now.Add(24 * time.Hour)
-
-	due := nowItem("20260417-tick_due", model.KindTickler, model.StatusActive)
-	due.DeferUntil = &past
-	writeItem(t, dir, due, "")
-
-	notYet := nowItem("20260417-tick_future", model.KindTickler, model.StatusActive)
-	notYet.DeferUntil = &future
-	writeItem(t, dir, notYet, "")
-
-	noDate := nowItem("20260417-tick_nodate", model.KindTickler, model.StatusActive)
-	writeItem(t, dir, noDate, "")
-
-	out, _, err := runCmd(t, dir, "engage", "tickler")
-	if err != nil {
-		t.Fatalf("engage tickler: %v", err)
-	}
-	if !strings.Contains(out, "20260417-tick_due") {
-		t.Errorf("missing due tickler: %q", out)
-	}
-	if strings.Contains(out, "20260417-tick_future") {
-		t.Errorf("should not include future tickler: %q", out)
-	}
-	if strings.Contains(out, "20260417-tick_nodate") {
-		t.Errorf("should not include dateless tickler: %q", out)
-	}
-}
-
-func TestEngageTicklerReviewAtFallback(t *testing.T) {
-	dir := setupDir(t)
-	now := time.Now()
-	past := now.Add(-24 * time.Hour)
-
-	tick := nowItem("20260417-tick_review", model.KindTickler, model.StatusActive)
-	tick.ReviewAt = &past
-	writeItem(t, dir, tick, "")
-
-	out, _, err := runCmd(t, dir, "engage", "tickler")
-	if err != nil {
-		t.Fatalf("engage tickler: %v", err)
-	}
-	if !strings.Contains(out, "20260417-tick_review") {
-		t.Errorf("missing review_at-triggered tickler: %q", out)
-	}
-}
-
 // ---------- reflect ----------
 
 func TestReflectNextActions(t *testing.T) {
@@ -1114,6 +1064,174 @@ func TestReflectLogInvalidStatus(t *testing.T) {
 		"--since", "2026-01-01", "--status", "active")
 	if err == nil {
 		t.Fatalf("expected error for non-terminal status, got nil; stderr=%q", stderr)
+	}
+}
+
+func TestReflectTickler(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	past := now.Add(-24 * time.Hour)
+	future := now.Add(24 * time.Hour)
+
+	due := nowItem("20260417-tick_due", model.KindTickler, model.StatusActive)
+	due.DeferUntil = &past
+	writeItem(t, dir, due, "")
+
+	notYet := nowItem("20260417-tick_future", model.KindTickler, model.StatusActive)
+	notYet.DeferUntil = &future
+	writeItem(t, dir, notYet, "")
+
+	noDate := nowItem("20260417-tick_nodate", model.KindTickler, model.StatusActive)
+	writeItem(t, dir, noDate, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "tickler")
+	if err != nil {
+		t.Fatalf("reflect tickler: %v", err)
+	}
+	if !strings.Contains(out, "20260417-tick_due") {
+		t.Errorf("missing due tickler: %q", out)
+	}
+	if strings.Contains(out, "20260417-tick_future") {
+		t.Errorf("should not include future tickler: %q", out)
+	}
+	if strings.Contains(out, "20260417-tick_nodate") {
+		t.Errorf("should not include dateless tickler: %q", out)
+	}
+}
+
+func TestReflectTicklerReviewAtFallback(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	past := now.Add(-24 * time.Hour)
+
+	tick := nowItem("20260417-tick_review", model.KindTickler, model.StatusActive)
+	tick.ReviewAt = &past
+	writeItem(t, dir, tick, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "tickler")
+	if err != nil {
+		t.Fatalf("reflect tickler: %v", err)
+	}
+	if !strings.Contains(out, "20260417-tick_review") {
+		t.Errorf("missing review_at-triggered tickler: %q", out)
+	}
+}
+
+func TestReflectTicklerPull(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	past := now.Add(-24 * time.Hour)
+	future := now.Add(24 * time.Hour)
+	reviewDate := now.Add(-48 * time.Hour)
+
+	fired := nowItem("20260417-pull_fired", model.KindTickler, model.StatusActive)
+	fired.DeferUntil = &past
+	fired.ReviewAt = &reviewDate
+	fired.CreatedAt = now.Add(-72 * time.Hour)
+	fired.UpdatedAt = now.Add(-72 * time.Hour)
+	writeItem(t, dir, fired, "body content")
+
+	waiting := nowItem("20260417-pull_future", model.KindTickler, model.StatusActive)
+	waiting.DeferUntil = &future
+	writeItem(t, dir, waiting, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "tickler", "--pull")
+	if err != nil {
+		t.Fatalf("reflect tickler --pull: %v", err)
+	}
+	if !strings.Contains(out, "20260417-pull_fired") {
+		t.Errorf("pulled ID not printed: %q", out)
+	}
+	if strings.Contains(out, "20260417-pull_future") {
+		t.Errorf("non-fired tickler should not be pulled: %q", out)
+	}
+
+	moved, body := readItem(t, dir, "20260417-pull_fired")
+	if moved.Kind != model.KindInbox {
+		t.Errorf("kind: want inbox, got %s", moved.Kind)
+	}
+	if moved.DeferUntil != nil {
+		t.Errorf("defer_until should be cleared, got %v", moved.DeferUntil)
+	}
+	if moved.ReviewAt == nil {
+		t.Errorf("review_at should be preserved")
+	}
+	if !moved.UpdatedAt.After(fired.UpdatedAt) {
+		t.Errorf("updated_at should be refreshed")
+	}
+	if body != "body content" {
+		t.Errorf("body: want %q, got %q", "body content", body)
+	}
+
+	cfg := config.New(dir)
+	oldPath := filepath.Join(cfg.DirForKind(model.KindTickler), "20260417-pull_fired.md")
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old tickler file should be gone, stat err=%v", err)
+	}
+
+	stillThere, _ := readItem(t, dir, "20260417-pull_future")
+	if stillThere.Kind != model.KindTickler {
+		t.Errorf("non-fired tickler moved: kind=%s", stillThere.Kind)
+	}
+}
+
+func TestReflectTicklerPullEmpty(t *testing.T) {
+	dir := setupDir(t)
+	future := time.Now().Add(24 * time.Hour)
+
+	pending := nowItem("20260417-tick_pending", model.KindTickler, model.StatusActive)
+	pending.DeferUntil = &future
+	writeItem(t, dir, pending, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "tickler", "--pull")
+	if err != nil {
+		t.Fatalf("reflect tickler --pull: %v", err)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output, got %q", out)
+	}
+}
+
+func TestReflectTicklerPullJSON(t *testing.T) {
+	dir := setupDir(t)
+	past := time.Now().Add(-24 * time.Hour)
+
+	fired := nowItem("20260417-json_fired", model.KindTickler, model.StatusActive)
+	fired.DeferUntil = &past
+	writeItem(t, dir, fired, "")
+
+	out, _, err := runCmd(t, dir, "--json", "reflect", "tickler", "--pull")
+	if err != nil {
+		t.Fatalf("reflect tickler --pull --json: %v", err)
+	}
+	var got struct {
+		Pulled []string `json:"pulled"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json parse: %v; out=%q", err, out)
+	}
+	if len(got.Pulled) != 1 || got.Pulled[0] != "20260417-json_fired" {
+		t.Errorf("pulled: want [20260417-json_fired], got %v", got.Pulled)
+	}
+}
+
+func TestReflectTicklerPullJSONEmpty(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "--json", "reflect", "tickler", "--pull")
+	if err != nil {
+		t.Fatalf("reflect tickler --pull --json: %v", err)
+	}
+	var got struct {
+		Pulled []string `json:"pulled"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json parse: %v; out=%q", err, out)
+	}
+	if got.Pulled == nil {
+		t.Errorf("pulled should be [] not null: %q", out)
+	}
+	if len(got.Pulled) != 0 {
+		t.Errorf("pulled should be empty, got %v", got.Pulled)
 	}
 }
 

--- a/internal/command/engage.go
+++ b/internal/command/engage.go
@@ -22,7 +22,6 @@ func newEngageCommand(c *container) *cobra.Command {
 		newEngageCancelCommand(c),
 		newEngageNextActionCommand(c),
 		newEngageWaitingCommand(c),
-		newEngageTicklerCommand(c),
 	)
 	return cmd
 }
@@ -148,49 +147,6 @@ func newEngageWaitingCommand(c *container) *cobra.Command {
 
 	cmd.Flags().IntVar(&staleDays, "stale-days", 7, "Stale threshold in days (items older than this are shown)")
 	return cmd
-}
-
-func newEngageTicklerCommand(c *container) *cobra.Command {
-	return &cobra.Command{
-		Use:   "tickler",
-		Short: "List tickler items whose trigger date has arrived",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			kind := model.KindTickler
-			status := model.StatusActive
-			items, err := store.List(c.cfg, store.Filter{Kind: &kind, Status: &status})
-			if err != nil {
-				return err
-			}
-			now := time.Now()
-			todayEnd := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, now.Location())
-
-			var due []*model.Item
-			triggers := make(map[string]time.Time)
-			for _, it := range items {
-				trigger := ticklerTrigger(it)
-				if trigger == nil || trigger.After(todayEnd) {
-					continue
-				}
-				due = append(due, it)
-				triggers[it.ID] = *trigger
-			}
-			sort.Slice(due, func(i, j int) bool {
-				return triggers[due[i].ID].Before(triggers[due[j].ID])
-			})
-			c.printer.PrintItems(due)
-			return nil
-		},
-	}
-}
-
-func ticklerTrigger(it *model.Item) *time.Time {
-	if it.DeferUntil != nil {
-		return it.DeferUntil
-	}
-	if it.ReviewAt != nil {
-		return it.ReviewAt
-	}
-	return nil
 }
 
 func matchAllTags(it *model.Item, tags []string) bool {

--- a/internal/command/reflect.go
+++ b/internal/command/reflect.go
@@ -22,6 +22,7 @@ func newReflectCommand(c *container) *cobra.Command {
 		newReflectWaitingCommand(c),
 		newReflectReviewCommand(c),
 		newReflectLogCommand(c),
+		newReflectTicklerCommand(c),
 	)
 	return cmd
 }
@@ -230,6 +231,76 @@ func newReflectLogCommand(c *container) *cobra.Command {
 	cmd.Flags().StringSliceVar(&statuses, "status", nil, "Filter by terminal status (repeatable; default: done)")
 	_ = cmd.MarkFlagRequired("since")
 	return cmd
+}
+
+func newReflectTicklerCommand(c *container) *cobra.Command {
+	var pull bool
+
+	cmd := &cobra.Command{
+		Use:   "tickler",
+		Short: "List fired tickler items, or pull them into the inbox with --pull",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kind := model.KindTickler
+			status := model.StatusActive
+			items, err := store.List(c.cfg, store.Filter{Kind: &kind, Status: &status})
+			if err != nil {
+				return err
+			}
+			now := time.Now()
+			todayEnd := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, now.Location())
+
+			var due []*model.Item
+			triggers := make(map[string]time.Time)
+			for _, it := range items {
+				trigger := ticklerTrigger(it)
+				if trigger == nil || trigger.After(todayEnd) {
+					continue
+				}
+				due = append(due, it)
+				triggers[it.ID] = *trigger
+			}
+			sort.Slice(due, func(i, j int) bool {
+				return triggers[due[i].ID].Before(triggers[due[j].ID])
+			})
+
+			if !pull {
+				c.printer.PrintItems(due)
+				return nil
+			}
+
+			pulled := make([]string, 0, len(due))
+			for _, it := range due {
+				src := store.PathForItem(c.cfg, it)
+				full, body, err := store.Read(src)
+				if err != nil {
+					return err
+				}
+				full.Kind = model.KindInbox
+				full.DeferUntil = nil
+				full.UpdatedAt = time.Now()
+				dst := store.PathForItem(c.cfg, full)
+				if err := store.Move(src, dst, full, body); err != nil {
+					return err
+				}
+				pulled = append(pulled, full.ID)
+			}
+			c.printer.PrintPulled(pulled)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&pull, "pull", false, "Move fired tickler items into the inbox")
+	return cmd
+}
+
+func ticklerTrigger(it *model.Item) *time.Time {
+	if it.DeferUntil != nil {
+		return it.DeferUntil
+	}
+	if it.ReviewAt != nil {
+		return it.ReviewAt
+	}
+	return nil
 }
 
 func parseLogStatuses(raw []string) (map[model.Status]struct{}, error) {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -59,6 +59,24 @@ func (p *Printer) PrintPaths(paths []string) {
 	}
 }
 
+// PrintPulled prints the result of `reflect tickler --pull`: one moved ID per
+// line in text mode, or `{"pulled": [...]}` in JSON mode.
+func (p *Printer) PrintPulled(ids []string) {
+	if p.json {
+		if ids == nil {
+			ids = []string{}
+		}
+		data, _ := json.Marshal(struct {
+			Pulled []string `json:"pulled"`
+		}{Pulled: ids})
+		fmt.Fprintln(p.out, string(data))
+		return
+	}
+	for _, id := range ids {
+		fmt.Fprintln(p.out, id)
+	}
+}
+
 func (p *Printer) PrintItem(item *model.Item, body string) {
 	if p.json {
 		p.printItemJSON(item, body)

--- a/plugins/htd/agents/reflect.md
+++ b/plugins/htd/agents/reflect.md
@@ -18,7 +18,8 @@ htd reflect projects --json
 htd reflect projects --stalled --json
 htd reflect waiting --json
 htd reflect review --json
-htd reflect done --since <7-days-ago-YYYY-MM-DD> --json
+htd reflect tickler --json
+htd reflect log --since <7-days-ago-YYYY-MM-DD> --json
 ```
 
 Compute the `--since` date from the current date minus 7 days. If the user passed a different range in the conversation, use that instead.
@@ -29,7 +30,7 @@ Produce a single Markdown report with these sections. Keep it scannable — coun
 
 ### Summary
 
-One-line counts: next actions ready, active projects, stalled projects, waiting-for total, items due for review, completed in the last 7 days.
+One-line counts: next actions ready, active projects, stalled projects, waiting-for total, items due for review, fired ticklers, completed in the last 7 days.
 
 ### Stalled projects
 
@@ -38,6 +39,10 @@ List every stalled project (no linked active next_action) with ID and title. For
 ### Review queue
 
 List items where `review_at` is today or past, sorted by `review_at` ascending. For each: ID, title, kind, review date.
+
+### Fired ticklers
+
+List ticklers whose trigger (`defer_until`, or `review_at` fallback) is today or past, sorted ascending. For each: ID, title, trigger date. If any are fired, suggest `/htd:daily-review` — it pulls them into the inbox so the normal clarify flow can re-decide each one. The reflect agent itself is read-only; it never pulls.
 
 ### Waiting-for
 
@@ -52,7 +57,7 @@ Count + a few titles from the last 7 days. This is a morale boost — keep it sh
 A bullet list of anything anomalous:
 - Projects with no next_action (repeat of stalled section, keep it here too).
 - Next actions with due dates in the past.
-- Items with `defer_until` that has already passed (should be visible now but might be forgotten).
+- Non-tickler items with `defer_until` that has already passed (ticklers are already covered above — this flag is for other kinds where a deferral may have been forgotten).
 - Any other pattern worth the user's attention.
 
 ## After the report

--- a/plugins/htd/commands/daily-review.md
+++ b/plugins/htd/commands/daily-review.md
@@ -1,0 +1,86 @@
+---
+name: daily-review
+description: Run the daily review — pull fired ticklers into the inbox, clear anything due, and surface what needs attention today. Use first thing in the morning or whenever the user says "let's do a daily review".
+---
+
+# Daily review
+
+You are running the user's daily review. Your job is to walk them through a short, predictable sequence that empties the tickler, processes any inbox that results, flags what's due, and surfaces what to work on. Keep it brisk — the user wants to finish and start doing, not sit in meta-work.
+
+Announce the flow ("Running your daily review — 5 quick steps.") and move through the steps in order.
+
+## 1. Pull fired ticklers
+
+Preview first:
+
+```bash
+htd reflect tickler --json
+```
+
+Parse the JSON. If empty, say so in one line and skip to step 2.
+
+Otherwise show the user the list (ID + title + trigger date). Ask for confirmation, then run:
+
+```bash
+htd reflect tickler --pull
+```
+
+The pulled items are now in the inbox as unclarified input — they're prompts to re-decide, not automatic next actions.
+
+## 2. Process the inbox
+
+Check what's there (includes anything just pulled):
+
+```bash
+htd clarify list --json
+```
+
+If the inbox is empty, say so and skip. Otherwise hand off to the clarify flow:
+
+> "You have N inbox items (including M pulled ticklers). Run `/htd:clarify` to walk through them, or I can start it now."
+
+Don't process the inbox inline — that belongs to the `/htd:clarify` subagent. Your job here is to surface the count and hand off cleanly.
+
+## 3. Review queue
+
+```bash
+htd reflect review --json
+```
+
+Items whose `review_at` is today or past. Summarize in one short block: count, and the top few (ID, title, kind, review date). If empty, say so.
+
+Don't prescribe an action — just surface. The user decides whether to open each one.
+
+## 4. Today's next actions
+
+```bash
+htd reflect next-actions --json
+```
+
+Summarize: total count, plus the top 3–5 by due date (soonest first, `-` for undated). Keep this to about 6 lines.
+
+## 5. Stale waiting-for
+
+```bash
+htd engage waiting --json
+```
+
+If nothing is ≥ 7 days old, say "nothing stale" and skip. Otherwise list the oldest 2–3 with age in days. Suggest `/htd:engage` to draft follow-ups if the user wants to chase them now.
+
+## Wrap-up
+
+One-line summary:
+
+```
+Daily review: <N> ticklers pulled, <M> inbox items to clarify, <K> review items, <L> next actions ready, <S> stale waiting.
+```
+
+Then stop. The user takes it from here.
+
+## Rules
+
+- **Confirm before `--pull`.** It's the one mutation in this flow; show the list and wait for yes before running.
+- **All reads use `--json`.** Parse, don't scrape.
+- **Don't mark anything done.** Completion belongs to `/htd:engage` and `htd engage done`.
+- **Don't clarify inbox items yourself.** Hand off to `/htd:clarify`.
+- **Stay tight.** This is a scan, not a deep session. If the user wants to dig into something, point them at the right phase command and stop.

--- a/plugins/htd/commands/engage.md
+++ b/plugins/htd/commands/engage.md
@@ -1,6 +1,6 @@
 ---
 name: engage
-description: Engage phase — show what demands action now (ready next actions, stale waiting, fired ticklers) and help drill into one.
+description: Engage phase — show what demands action now (ready next actions, stale waiting) and help drill into one.
 ---
 
 # Engage phase
@@ -14,7 +14,7 @@ Run these three in parallel and parse the JSON:
 ```bash
 htd engage next-action --json
 htd engage waiting --json
-htd engage tickler --json
+htd reflect tickler --json
 ```
 
 Summarize in a short block — counts plus the top couple of items per category. For example:
@@ -22,14 +22,16 @@ Summarize in a short block — counts plus the top couple of items per category.
 ```
 Ready next actions: 7 (top: "Write man page", "Review PR #42")
 Stale waiting-for: 2 (oldest: "Client sign-off", 14 days)
-Fired ticklers: 1 ("Quarterly review prep", was due 2 days ago)
+Fired ticklers: 1 (run /htd:daily-review to process)
 ```
 
-If all three are empty, tell the user their plate is clear and stop.
+If the fired-tickler count is > 0, point the user at `/htd:daily-review` — tickler processing is a Reflect-phase concern (empty into inbox, re-clarify) and doesn't belong in Engage. Don't drill into it here.
+
+If everything is empty, tell the user their plate is clear and stop.
 
 ## Drill-down
 
-Ask which of the three (or "done", "none") they want to dive into:
+Ask which category (or "done", "none") they want to dive into:
 
 ### a. Pick a next action
 
@@ -50,20 +52,10 @@ For the stale items, help the user nudge the person they're waiting on:
 3. Draft a concise follow-up message in English. Show it to the user to copy and send manually. **Do not send anything — the plugin has no channel access.**
 4. Offer to update the item after they send it: `htd clarify update <id> --body "<note about the follow-up>"` or `htd item update <id>`. This refreshes `updated_at` and drops the item out of the stale list.
 
-### c. Process fired ticklers
-
-For each tickler whose date has fired:
-
-1. Show the item and the date it fired.
-2. Ask: does it become a real action now, or defer again?
-   - Become actionable → `htd organize move <id> next_action` (and optionally link to a project / set due date).
-   - Defer again → `htd organize schedule <id> --defer YYYY-MM-DD`.
-   - No longer needed → `htd engage cancel <id>`.
-3. Confirm before each command.
-
 ## Rules
 
 - **Don't mark anything done in this command.** Completion happens via `htd engage done <id>` as a separate step once the user finishes the work.
 - **Always confirm mutating commands.** Show the exact `htd` call and wait.
 - **Don't send messages to anyone.** You draft follow-ups; the user sends them.
+- **Don't process ticklers inline.** Hand off to `/htd:daily-review`, which pulls them into the inbox for clarify.
 - Use `--json` for every read and parse the output. Don't scrape the human-readable format.

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -69,12 +69,12 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 - `htd reflect projects [--stalled]`
 - `htd reflect waiting`
 - `htd reflect review` — items whose `review_at` is due.
-- `htd reflect done --since YYYY-MM-DD`
+- `htd reflect log --since YYYY-MM-DD [--until DATE] [--kind KIND] [--tag TAG]... [--status STATUS]...` — recently resolved items (activity log). Defaults to `--status done`.
+- `htd reflect tickler [--pull]` — ticklers whose `defer_until` (or `review_at` fallback) is today or past. With `--pull`, move them into the inbox for re-clarification (clears `defer_until`, keeps `review_at`).
 
 **Engage** (act on the system)
 - `htd engage next-action [--project ID] [--tag T]...` — what's ready to work on now.
 - `htd engage waiting [--stale-days N]` — waiting-for items untouched ≥ N days (default 7). JSON includes `age_days`.
-- `htd engage tickler` — ticklers whose `defer_until` (or `review_at` fallback) is today or past.
 - `htd engage done ID`
 - `htd engage cancel ID`
 
@@ -93,9 +93,10 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 | "my inbox is full", "process my inbox" | `/htd:clarify` (walks item-by-item) |
 | "categorize this", "link this to project Y", "set a due date" | `/htd:organize` |
 | "weekly review", "how's my system looking", "what's stalled" | `/htd:reflect` |
+| "daily review", "morning routine", "let's start the day" | `/htd:daily-review` |
 | "what should I work on now", "what's on my plate today" | `/htd:engage` |
 | Chasing a delegated task | `/htd:engage` → drill into waiting |
-| Tickler for date X fires | `/htd:engage` → drill into ticklers; promote to next_action |
+| Tickler for date X fires | `/htd:daily-review` (pulls fired ticklers into the inbox, then clarify decides) |
 | Completing a task | `htd engage done ID` (direct call is fine) |
 
 ## Interaction principles


### PR DESCRIPTION
## Summary

- Moves tickler review from **Engage** to **Reflect** and adds `htd reflect tickler [--pull]`. Without `--pull`, lists fired ticklers (same output as the old `engage tickler`). With `--pull`, moves them to `items/inbox/`: `kind: inbox`, `defer_until` cleared, `updated_at` refreshed, `review_at` preserved.
- Removes `htd engage tickler`. Breaking change; the CLI is pre-1.0 and the replacement is a strict superset.
- Adds `/htd:daily-review` to the plugin — an opinionated morning routine that previews/pulls fired ticklers, hands off to `/htd:clarify`, and surfaces review queue, next actions, and stale waiting. `/htd:engage` no longer drills into ticklers and points users at the new command instead.
- Fixes a stale `htd reflect done` reference in the plugin (renamed to `reflect log` in #17; plugin wasn't updated).

## Why

Issue #6 proposed either auto-mixing fired ticklers into `engage next-action` or a bulk `engage fire-ticklers` that promotes them to `next_action`. Both skip a step the underlying methodology treats as non-negotiable: a fired tickler is "unprocessed" and must re-enter the in-tray for re-clarification — the tickler defers the *decision*, not the action. The user may want to reschedule, delegate, drop to someday, or discard.

The same methodology places tickler handling in the daily review's Reflect mode, not Engage. Hosting `tickler` under `engage` was phase-incorrect from the start.

Orchestration of the full Daily/Weekly Review ceremony stays in the plugin — CLI keeps to primitives.

## Test plan

- [x] `mise run lint` clean
- [x] `mise run test` green; new tests cover list, `--pull`, JSON shape (`{pulled:[...]}`), empty result (empty array, not null), `review_at` fallback trigger, and `review_at` preservation on pull
- [x] Manual smoke: created fired and non-fired tickler fixtures; `reflect tickler` listed only the fired one; `reflect tickler --pull` moved the fired item to `items/inbox/` with `defer_until` cleared and `review_at` kept; non-fired stayed; second `reflect tickler` was empty; `engage tickler` now shows usage output
- [ ] Plugin smoke: install locally, run `/htd:daily-review` end to end (reviewer discretion)

Closes #6