### PR TITLE
Accept multiple IDs on organize move and engage done/cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ htd clarify discard ID
 ### Organize
 
 ```
-htd organize move ID KIND
+htd organize move KIND ID [ID...]
 htd organize link ID --project PROJECT_ID
 htd organize schedule ID [--due DATE] [--defer DATE] [--review DATE]
 ```
@@ -73,8 +73,8 @@ htd reflect done --since DATE
 htd engage next-action [--project PROJECT_ID] [--tag TAG]...
 htd engage waiting [--stale-days N]
 htd engage tickler
-htd engage done ID
-htd engage cancel ID
+htd engage done ID [ID...]
+htd engage cancel ID [ID...]
 ```
 
 The list commands surface what demands action now: next actions ready to work on, waiting-for items untouched for `--stale-days` or more (default 7), and ticklers whose trigger date has arrived.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -199,28 +199,36 @@ Categorize, link, and schedule items.
 
 ### 4.1 `htd organize move`
 
-Change an item's category (kind). Moves the file to the corresponding directory.
+Change the category (kind) of one or more items. Moves each file to the corresponding directory.
 
 ```
-htd organize move ID KIND
+htd organize move KIND ID [ID...]
 ```
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `ID` | yes | The item ID |
 | `KIND` | yes | Target kind: `next_action`, `project`, `waiting_for`, `someday`, `tickler` |
+| `ID` | yes | One or more item IDs to move to `KIND` |
 
 **Behavior:**
 
-1. Find the item file across all `items/<kind>/` directories.
-2. Update `kind` in front matter to the new value.
-3. Set `updated_at` to the current timestamp.
-4. Move the file to `items/<new-kind>/<id>.md`.
+1. For each `ID`, in order:
+   1. Find the item file across all `items/<kind>/` directories.
+   2. Update `kind` in front matter to `KIND`.
+   3. Set `updated_at` to the current timestamp.
+   4. Move the file to `items/<new-kind>/<id>.md`.
+2. On the first failure (missing ID, terminal status, etc.), stop processing and exit with an error. IDs processed before the failure remain moved.
 
 **Constraints:**
 
 - Cannot move to `inbox` (items enter inbox only via `capture add`).
 - Cannot move archived items (status must be `active`).
+
+**Example:**
+
+```
+$ htd organize move someday 20260417-read_article 20260417-try_tool 20260417-watch_talk
+```
 
 ### 4.2 `htd organize link`
 
@@ -460,18 +468,20 @@ Choose and complete work.
 
 ### 6.1 `htd engage done`
 
-Mark an item as completed.
+Mark one or more items as completed.
 
 ```
-htd engage done ID
+htd engage done ID [ID...]
 ```
 
 **Behavior:**
 
-1. Find the item across all `items/<kind>/` directories.
-2. Set `status: done`.
-3. Set `updated_at` to the current timestamp.
-4. Move the file to `archive/items/<id>.md`.
+1. For each `ID`, in order:
+   1. Find the item across all `items/<kind>/` directories.
+   2. Set `status: done`.
+   3. Set `updated_at` to the current timestamp.
+   4. Move the file to `archive/items/<id>.md`.
+2. On the first failure (missing ID, already-terminal item, etc.), stop processing and exit with an error. IDs processed before the failure remain marked done.
 
 **Constraints:**
 
@@ -479,18 +489,20 @@ htd engage done ID
 
 ### 6.2 `htd engage cancel`
 
-Cancel an active item that is no longer being pursued.
+Cancel one or more active items that are no longer being pursued.
 
 ```
-htd engage cancel ID
+htd engage cancel ID [ID...]
 ```
 
 **Behavior:**
 
-1. Find the item across all `items/<kind>/` directories.
-2. Set `status: canceled`.
-3. Set `updated_at` to the current timestamp.
-4. Move the file to `archive/items/<id>.md`.
+1. For each `ID`, in order:
+   1. Find the item across all `items/<kind>/` directories.
+   2. Set `status: canceled`.
+   3. Set `updated_at` to the current timestamp.
+   4. Move the file to `archive/items/<id>.md`.
+2. On the first failure, stop processing and exit with an error. IDs processed before the failure remain canceled.
 
 **Constraints:**
 
@@ -714,7 +726,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd clarify show ID` | Show an inbox item |
 | `htd clarify update ID` | Update an inbox item |
 | `htd clarify discard ID` | Discard an inbox item |
-| `htd organize move ID KIND` | Change item category |
+| `htd organize move KIND ID [ID...]` | Change the category of one or more items |
 | `htd organize link ID --project PID` | Link item to a project |
 | `htd organize schedule ID` | Set dates on an item |
 | `htd organize promote ID --child TITLE...` | Promote to a project with next-action children |
@@ -724,8 +736,8 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd reflect review` | List items due for review |
 | `htd reflect log --since DATE` | List recently resolved items (activity log) |
 | `htd reflect tickler [--pull]` | List fired tickler items, or pull them into the inbox |
-| `htd engage done ID` | Mark an item as done |
-| `htd engage cancel ID` | Cancel an active item |
+| `htd engage done ID [ID...]` | Mark one or more items as done |
+| `htd engage cancel ID [ID...]` | Cancel one or more active items |
 | `htd engage next-action` | List next actions ready to work on now |
 | `htd engage waiting` | List waiting-for items that need follow-up |
 | `htd item get ID` | Get any item by ID |

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -294,7 +294,7 @@ func TestOrganizeMove(t *testing.T) {
 	dir := setupDir(t)
 	writeItem(t, dir, nowItem("20260417-move_me", model.KindInbox, model.StatusActive), "")
 
-	_, _, err := runCmd(t, dir, "organize", "move", "20260417-move_me", "next_action")
+	_, _, err := runCmd(t, dir, "organize", "move", "next_action", "20260417-move_me")
 	if err != nil {
 		t.Fatalf("organize move: %v", err)
 	}
@@ -315,9 +315,52 @@ func TestOrganizeMoveToInboxFails(t *testing.T) {
 	dir := setupDir(t)
 	writeItem(t, dir, nowItem("20260417-some", model.KindNextAction, model.StatusActive), "")
 
-	_, _, err := runCmd(t, dir, "organize", "move", "20260417-some", "inbox")
+	_, _, err := runCmd(t, dir, "organize", "move", "inbox", "20260417-some")
 	if err == nil {
 		t.Error("expected error when moving to inbox")
+	}
+}
+
+func TestOrganizeMoveBulk(t *testing.T) {
+	dir := setupDir(t)
+	for _, id := range []string{"20260417-bm1", "20260417-bm2", "20260417-bm3"} {
+		writeItem(t, dir, nowItem(id, model.KindInbox, model.StatusActive), "")
+	}
+
+	_, _, err := runCmd(t, dir, "organize", "move", "someday",
+		"20260417-bm1", "20260417-bm2", "20260417-bm3")
+	if err != nil {
+		t.Fatalf("organize move (bulk): %v", err)
+	}
+
+	for _, id := range []string{"20260417-bm1", "20260417-bm2", "20260417-bm3"} {
+		got, _ := readItem(t, dir, id)
+		if got.Kind != model.KindSomeday {
+			t.Errorf("%s kind: want someday, got %q", id, got.Kind)
+		}
+	}
+}
+
+func TestOrganizeMoveBulkStopsOnFirstError(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-bm_ok", model.KindInbox, model.StatusActive), "")
+
+	_, _, err := runCmd(t, dir, "organize", "move", "someday",
+		"20260417-bm_ok", "20260417-bm_missing")
+	if err == nil {
+		t.Fatal("expected error when an ID is missing")
+	}
+	got, _ := readItem(t, dir, "20260417-bm_ok")
+	if got.Kind != model.KindSomeday {
+		t.Errorf("earlier ID should be moved before failure: got kind %q", got.Kind)
+	}
+}
+
+func TestOrganizeMoveRequiresID(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "organize", "move", "someday")
+	if err == nil {
+		t.Error("expected error when no IDs are given")
 	}
 }
 
@@ -557,6 +600,25 @@ func TestEngageDone(t *testing.T) {
 	}
 }
 
+func TestEngageDoneBulk(t *testing.T) {
+	dir := setupDir(t)
+	ids := []string{"20260417-bd1", "20260417-bd2", "20260417-bd3"}
+	for _, id := range ids {
+		writeItem(t, dir, nowItem(id, model.KindNextAction, model.StatusActive), "")
+	}
+
+	_, _, err := runCmd(t, dir, append([]string{"engage", "done"}, ids...)...)
+	if err != nil {
+		t.Fatalf("engage done (bulk): %v", err)
+	}
+	for _, id := range ids {
+		got, _ := readItem(t, dir, id)
+		if got.Status != model.StatusDone {
+			t.Errorf("%s status: want done, got %q", id, got.Status)
+		}
+	}
+}
+
 func TestEngageCancel(t *testing.T) {
 	dir := setupDir(t)
 	writeItem(t, dir, nowItem("20260417-cancel_me", model.KindNextAction, model.StatusActive), "")
@@ -569,6 +631,39 @@ func TestEngageCancel(t *testing.T) {
 	got, _ := readItem(t, dir, "20260417-cancel_me")
 	if got.Status != model.StatusCanceled {
 		t.Errorf("status: want canceled, got %q", got.Status)
+	}
+}
+
+func TestEngageCancelBulk(t *testing.T) {
+	dir := setupDir(t)
+	ids := []string{"20260417-bc1", "20260417-bc2"}
+	for _, id := range ids {
+		writeItem(t, dir, nowItem(id, model.KindNextAction, model.StatusActive), "")
+	}
+
+	_, _, err := runCmd(t, dir, append([]string{"engage", "cancel"}, ids...)...)
+	if err != nil {
+		t.Fatalf("engage cancel (bulk): %v", err)
+	}
+	for _, id := range ids {
+		got, _ := readItem(t, dir, id)
+		if got.Status != model.StatusCanceled {
+			t.Errorf("%s status: want canceled, got %q", id, got.Status)
+		}
+	}
+}
+
+func TestEngageDoneBulkStopsOnFirstError(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-bd_ok", model.KindNextAction, model.StatusActive), "")
+
+	_, _, err := runCmd(t, dir, "engage", "done", "20260417-bd_ok", "20260417-bd_missing")
+	if err == nil {
+		t.Fatal("expected error when an ID is missing")
+	}
+	got, _ := readItem(t, dir, "20260417-bd_ok")
+	if got.Status != model.StatusDone {
+		t.Errorf("earlier ID should be marked done before failure: got status %q", got.Status)
 	}
 }
 

--- a/internal/command/engage.go
+++ b/internal/command/engage.go
@@ -28,22 +28,32 @@ func newEngageCommand(c *container) *cobra.Command {
 
 func newEngageDoneCommand(c *container) *cobra.Command {
 	return &cobra.Command{
-		Use:   "done ID",
-		Short: "Mark an item as completed",
-		Args:  cobra.ExactArgs(1),
+		Use:   "done ID [ID...]",
+		Short: "Mark one or more items as completed",
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return terminateItem(c, args[0], model.StatusDone)
+			for _, id := range args {
+				if err := terminateItem(c, id, model.StatusDone); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
 }
 
 func newEngageCancelCommand(c *container) *cobra.Command {
 	return &cobra.Command{
-		Use:   "cancel ID",
-		Short: "Cancel an active item",
-		Args:  cobra.ExactArgs(1),
+		Use:   "cancel ID [ID...]",
+		Short: "Cancel one or more active items",
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return terminateItem(c, args[0], model.StatusCanceled)
+			for _, id := range args {
+				if err := terminateItem(c, id, model.StatusCanceled); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/internal/command/organize.go
+++ b/internal/command/organize.go
@@ -27,12 +27,12 @@ func newOrganizeCommand(c *container) *cobra.Command {
 
 func newOrganizeMoveCommand(c *container) *cobra.Command {
 	return &cobra.Command{
-		Use:   "move ID KIND",
-		Short: "Change an item's category",
-		Args:  cobra.ExactArgs(2),
+		Use:   "move KIND ID [ID...]",
+		Short: "Change the category of one or more items",
+		Args:  cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			itemID := args[0]
-			newKind := model.Kind(args[1])
+			newKind := model.Kind(args[0])
+			ids := args[1:]
 
 			if newKind == model.KindInbox {
 				return fmt.Errorf("cannot move items to inbox; items enter inbox only via 'capture add'")
@@ -41,27 +41,35 @@ func newOrganizeMoveCommand(c *container) *cobra.Command {
 				return fmt.Errorf("invalid kind %q", newKind)
 			}
 
-			path, err := store.FindItem(c.cfg, itemID)
-			if err != nil {
-				return err
+			for _, itemID := range ids {
+				if err := moveItem(c, itemID, newKind); err != nil {
+					return err
+				}
 			}
-			item, body, err := store.Read(path)
-			if err != nil {
-				return err
-			}
-			if !model.IsActive(item.Status) {
-				return fmt.Errorf("cannot move item with status %q", item.Status)
-			}
-
-			item.Kind = newKind
-			item.UpdatedAt = time.Now()
-			newPath := store.PathForItem(c.cfg, item)
-			if path == newPath {
-				return store.Write(path, item, body)
-			}
-			return store.Move(path, newPath, item, body)
+			return nil
 		},
 	}
+}
+
+func moveItem(c *container, itemID string, newKind model.Kind) error {
+	path, err := store.FindItem(c.cfg, itemID)
+	if err != nil {
+		return err
+	}
+	item, body, err := store.Read(path)
+	if err != nil {
+		return err
+	}
+	if !model.IsActive(item.Status) {
+		return fmt.Errorf("cannot move item with status %q", item.Status)
+	}
+	item.Kind = newKind
+	item.UpdatedAt = time.Now()
+	newPath := store.PathForItem(c.cfg, item)
+	if path == newPath {
+		return store.Write(path, item, body)
+	}
+	return store.Move(path, newPath, item, body)
 }
 
 func newOrganizeLinkCommand(c *container) *cobra.Command {

--- a/plugins/htd/agents/clarify.md
+++ b/plugins/htd/agents/clarify.md
@@ -26,17 +26,17 @@ You run the Clarify phase of the htd workflow. Your job is to turn every inbox i
 
    a. **Is it actionable?**
       - No, and not worth keeping → `htd clarify discard <id>`.
-      - No, but might be later → move to `someday`: `htd organize move <id> someday`.
-      - No, it's a time-triggered reminder → move to `tickler`, then ask for a defer date: `htd organize move <id> tickler` then `htd organize schedule <id> --defer YYYY-MM-DD`.
+      - No, but might be later → move to `someday`: `htd organize move someday <id>`. If several items share this disposition, pass them all in one call: `htd organize move someday <id1> <id2> ...`.
+      - No, it's a time-triggered reminder → move to `tickler`, then ask for a defer date: `htd organize move tickler <id>` then `htd organize schedule <id> --defer YYYY-MM-DD`.
       - Yes → continue.
 
    b. **Does it need more than one action?**
-      - Yes → it's a project. Ask: "What are the first next actions for this project?" (one or more short titles) and run `htd organize promote <id> --child "<title 1>" [--child "<title 2>"]...` in a single command. This promotes the parent to `project`, creates each child as `next_action`, and links them all in one shot. If the user can't name any children yet, fall back to `htd organize move <id> project` alone and revisit later.
+      - Yes → it's a project. Ask: "What are the first next actions for this project?" (one or more short titles) and run `htd organize promote <id> --child "<title 1>" [--child "<title 2>"]...` in a single command. This promotes the parent to `project`, creates each child as `next_action`, and links them all in one shot. If the user can't name any children yet, fall back to `htd organize move project <id>` alone and revisit later.
       - No → continue.
 
    c. **Am I the one doing it?**
-      - No, someone else is → waiting_for: `htd organize move <id> waiting_for`. Optionally ask who and add as a tag or note it in the body via `htd clarify update`.
-      - Yes → it's a next action: `htd organize move <id> next_action`.
+      - No, someone else is → waiting_for: `htd organize move waiting_for <id>`. Optionally ask who and add as a tag or note it in the body via `htd clarify update`.
+      - Yes → it's a next action: `htd organize move next_action <id>`.
 
 4. **Offer optional refinements** (never push):
    - Update the title if unclear: `htd clarify update <id> --title "<new>"`.

--- a/plugins/htd/commands/organize.md
+++ b/plugins/htd/commands/organize.md
@@ -24,7 +24,7 @@ If `$ARGUMENTS` is empty, ask which item they want to organize (offer to show `h
 
 3. Propose organization changes based on the title and body. Ask the user about each dimension that could be set, but skip ones that are already reasonable. For each proposal, show the exact `htd` command and wait for confirmation before running.
 
-   - **Kind** — if it's still `inbox` or the wrong kind, suggest one of next_action / project / waiting_for / someday / tickler and run `htd organize move <id> <kind>`. Cannot target `inbox`. If the item clearly needs to become a project with obvious first sub-actions, prefer `htd organize promote <id> --child "<title 1>" [--child "<title 2>"]...` to promote and seed children in one shot.
+   - **Kind** — if it's still `inbox` or the wrong kind, suggest one of next_action / project / waiting_for / someday / tickler and run `htd organize move <kind> <id>`. Cannot target `inbox`. If the item clearly needs to become a project with obvious first sub-actions, prefer `htd organize promote <id> --child "<title 1>" [--child "<title 2>"]...` to promote and seed children in one shot.
    - **Project link** — if the item looks related to an existing project, suggest it. To find candidates: `htd item list --kind project --status active --json`. Run `htd organize link <id> --project <project-id>` to link, or `--project ""` to clear.
    - **Dates** — if the user mentions timing ("next week", "by Friday", "defer until the 15th"), convert to `YYYY-MM-DD` and run `htd organize schedule <id> [--due …] [--defer …] [--review …]`. Pass `""` to clear a date.
    - **Tags** — if the user wants to tag: `htd item update <id> tags='[a,b]'`.

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -59,7 +59,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 - `htd clarify discard ID`
 
 **Organize**
-- `htd organize move ID KIND` — KIND ∈ {next_action, project, waiting_for, someday, tickler}; cannot target `inbox`.
+- `htd organize move KIND ID [ID...]` — KIND ∈ {next_action, project, waiting_for, someday, tickler}; cannot target `inbox`. Accepts multiple IDs for a shared disposition in one shot.
 - `htd organize link ID --project PROJECT_ID` — empty string to unlink.
 - `htd organize schedule ID [--due DATE] [--defer DATE] [--review DATE]` — empty string to clear. Dates accept `YYYY-MM-DD` or RFC 3339.
 - `htd organize promote ID --child TITLE [--child TITLE]...` — one-shot promote an item to a project and create linked next-action children. Prefer this over the move+capture+link chain when clarifying an item that clearly needs sub-actions.
@@ -75,8 +75,8 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 **Engage** (act on the system)
 - `htd engage next-action [--project ID] [--tag T]...` — what's ready to work on now.
 - `htd engage waiting [--stale-days N]` — waiting-for items untouched ≥ N days (default 7). JSON includes `age_days`.
-- `htd engage done ID`
-- `htd engage cancel ID`
+- `htd engage done ID [ID...]` — accepts multiple IDs.
+- `htd engage cancel ID [ID...]` — accepts multiple IDs.
 
 **Item (low-level CRUD)** — use for scripting; workflow commands are preferred.
 - `htd item get ID`


### PR DESCRIPTION
## Summary

- `htd organize move` now accepts multiple IDs: `organize move KIND ID [ID...]` (positional order flipped from `ID KIND`).
- `htd engage done` and `htd engage cancel` each accept multiple IDs: `engage done ID [ID...]` / `engage cancel ID [ID...]`.
- Processing is sequential and stops on the first error; IDs handled before the failure keep their new state.

This makes the clarify rhythm smooth when several siblings share a disposition — e.g. `htd organize move someday <id1> <id2> <id3>` in one call instead of three.

### Breaking change

`organize move` positional order is flipped: kind first, then one or more IDs. All call-sites in the repo (docs, plugin skills/commands, agent guidance) were updated to match.

## Test plan

- [x] `mise run test` — unit tests pass, new coverage:
  - bulk move across multiple IDs
  - bulk move stops on first failure, earlier IDs stay moved
  - `organize move` errors when no IDs are passed
  - bulk `engage done` / `engage cancel`
  - bulk `engage done` stops on first failure
- [x] `mise run lint` — clean.

Closes #7