### PR TITLE
Add htd item restore to undo accidental terminal transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ htd item get ID
 htd item list [--kind KIND] [--status STATUS] [--tag TAG] [--project PROJECT_ID]
 htd item update ID FIELD=VALUE [FIELD=VALUE]...
 htd item archive ID
+htd item restore ID
 ```
 
 ## Global options

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -643,6 +643,27 @@ htd item archive ID
 - Only active items can be archived this way.
 - Prefer `engage done` or `engage cancel` for normal workflow completion. Use `item archive` only when an item needs to be removed from active lists without a clear done/canceled semantics (e.g., a project that was superseded rather than finished).
 
+### 7.5 `htd item restore`
+
+Bring a terminal item back to active status. Symmetric to `engage done` / `engage cancel` / `item archive`.
+
+```
+htd item restore ID
+```
+
+**Behavior:**
+
+1. Find the item in `archive/items/`.
+2. Set `status: active`.
+3. Set `updated_at` to the current timestamp.
+4. Move the file back to `items/<kind>/<id>.md`, based on the item's `kind` front-matter value.
+
+**Constraints:**
+
+- The item must have a terminal status (`done`, `canceled`, `discarded`, or `archived`). Restoring an already-active item fails.
+- Restoring a `discarded` inbox item lands it back in `items/inbox/` for re-clarification.
+- Use this for error correction when an item was terminated by mistake; prefer `item update` only when field-level edits are truly needed.
+
 ---
 
 ## 8. Init
@@ -744,4 +765,5 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd item list` | List items with filters |
 | `htd item update ID` | Update item fields directly |
 | `htd item archive ID` | Archive an item (last resort) |
+| `htd item restore ID` | Restore a terminal item to active status |
 | `htd completion SHELL` | Emit a shell completion script |

--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -121,7 +121,7 @@ stateDiagram-v2
 - `organize move` changes an item's kind within the `active` state; it does not affect status.
 - `discarded` is only reachable from `inbox` via `clarify discard`.
 - `capture add --done` bypasses the inbox entirely: the item is born with `kind: next_action`, `status: done`, and is written directly to `archive/items/`. This is not a violation of the "inbox items cannot go directly to done" rule because the item never has `kind: inbox` at any point.
-- All terminal transitions are one-way. Items cannot return to `active` (use `htd item update` for error correction only).
+- Terminal transitions are one-way in normal workflow. For error correction (e.g. `engage done` run on the wrong ID), use `htd item restore` to bring a terminal item back to `active`; the file is moved back to `items/<kind>/` based on its recorded `kind`.
 
 ---
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -111,7 +111,7 @@ The file format and directory layout are optimized for AI agent access:
 3. **`done` or `canceled` for list items** — Items that have left the inbox have a clear lifecycle: either they are completed (`done`) or abandoned (`canceled`). There is no ambiguity about which terminal state to use.
 4. **`archived` is a last resort** — `item archive` exists for edge cases where neither `done` nor `canceled` semantically applies (e.g., a project superseded by another). Normal workflow should always end with `done` or `canceled`.
 5. **A project must have at least one next action** — Stalled projects (those with no linked `next_action` items) are flagged during `reflect projects --stalled`.
-6. **Terminal items are nearly immutable** — Items with status `done`, `canceled`, `discarded`, or `archived` should not be modified except for correcting errors via `htd item update`.
+6. **Terminal items are nearly immutable** — Items with status `done`, `canceled`, `discarded`, or `archived` should not be modified except for correcting errors: use `htd item restore` to undo an accidental termination, or `htd item update` for field-level edits.
 
 ---
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1423,6 +1423,114 @@ func TestItemArchive(t *testing.T) {
 	}
 }
 
+func TestItemRestoreDone(t *testing.T) {
+	dir := setupDir(t)
+	done := nowItem("20260417-restore_done", model.KindNextAction, model.StatusDone)
+	writeItem(t, dir, done, "body preserved")
+
+	_, _, err := runCmd(t, dir, "item", "restore", "20260417-restore_done")
+	if err != nil {
+		t.Fatalf("item restore: %v", err)
+	}
+
+	got, body := readItem(t, dir, "20260417-restore_done")
+	if got.Status != model.StatusActive {
+		t.Errorf("status: want active, got %q", got.Status)
+	}
+	if got.Kind != model.KindNextAction {
+		t.Errorf("kind: want next_action, got %q", got.Kind)
+	}
+	if body != "body preserved" {
+		t.Errorf("body: want %q, got %q", "body preserved", body)
+	}
+	if !got.UpdatedAt.After(done.UpdatedAt) {
+		t.Errorf("updated_at should be refreshed")
+	}
+
+	cfg := config.New(dir)
+	newPath := filepath.Join(cfg.DirForKind(model.KindNextAction), "20260417-restore_done.md")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Errorf("restored item not at %q: %v", newPath, err)
+	}
+	archivePath := filepath.Join(cfg.ArchiveItemsDir(), "20260417-restore_done.md")
+	if _, err := os.Stat(archivePath); !os.IsNotExist(err) {
+		t.Errorf("archive copy should be removed, stat err=%v", err)
+	}
+}
+
+func TestItemRestoreCanceled(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-restore_cancel", model.KindProject, model.StatusCanceled), "")
+
+	_, _, err := runCmd(t, dir, "item", "restore", "20260417-restore_cancel")
+	if err != nil {
+		t.Fatalf("item restore: %v", err)
+	}
+	got, _ := readItem(t, dir, "20260417-restore_cancel")
+	if got.Status != model.StatusActive {
+		t.Errorf("status: want active, got %q", got.Status)
+	}
+	cfg := config.New(dir)
+	newPath := filepath.Join(cfg.DirForKind(model.KindProject), "20260417-restore_cancel.md")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Errorf("restored item not in project dir: %v", err)
+	}
+}
+
+func TestItemRestoreDiscardedReturnsToInbox(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-restore_disc", model.KindInbox, model.StatusDiscarded), "")
+
+	_, _, err := runCmd(t, dir, "item", "restore", "20260417-restore_disc")
+	if err != nil {
+		t.Fatalf("item restore: %v", err)
+	}
+	got, _ := readItem(t, dir, "20260417-restore_disc")
+	if got.Status != model.StatusActive {
+		t.Errorf("status: want active, got %q", got.Status)
+	}
+	if got.Kind != model.KindInbox {
+		t.Errorf("kind: want inbox, got %q", got.Kind)
+	}
+	cfg := config.New(dir)
+	newPath := filepath.Join(cfg.DirForKind(model.KindInbox), "20260417-restore_disc.md")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Errorf("restored item not in inbox dir: %v", err)
+	}
+}
+
+func TestItemRestoreArchived(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-restore_arch", model.KindSomeday, model.StatusArchived), "")
+
+	_, _, err := runCmd(t, dir, "item", "restore", "20260417-restore_arch")
+	if err != nil {
+		t.Fatalf("item restore: %v", err)
+	}
+	got, _ := readItem(t, dir, "20260417-restore_arch")
+	if got.Status != model.StatusActive {
+		t.Errorf("status: want active, got %q", got.Status)
+	}
+}
+
+func TestItemRestoreActiveFails(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-restore_live", model.KindNextAction, model.StatusActive), "")
+
+	_, _, err := runCmd(t, dir, "item", "restore", "20260417-restore_live")
+	if err == nil {
+		t.Error("expected error when restoring an already-active item")
+	}
+}
+
+func TestItemRestoreNotFound(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "item", "restore", "20260417-ghost")
+	if !store.IsNotFound(err) {
+		t.Errorf("expected NotFoundError, got %v", err)
+	}
+}
+
 // ---------- init ----------
 
 func TestInitCreatesDirectories(t *testing.T) {

--- a/internal/command/item.go
+++ b/internal/command/item.go
@@ -21,6 +21,7 @@ func newItemCommand(c *container) *cobra.Command {
 		newItemListCommand(c),
 		newItemUpdateCommand(c),
 		newItemArchiveCommand(c),
+		newItemRestoreCommand(c),
 	)
 	return cmd
 }
@@ -214,6 +215,32 @@ func newItemArchiveCommand(c *container) *cobra.Command {
 				return fmt.Errorf("item %q is not active (status: %s)", itemID, item.Status)
 			}
 			item.Status = model.StatusArchived
+			item.UpdatedAt = time.Now()
+			newPath := store.PathForItem(c.cfg, item)
+			return store.Move(path, newPath, item, body)
+		},
+	}
+}
+
+func newItemRestoreCommand(c *container) *cobra.Command {
+	return &cobra.Command{
+		Use:   "restore ID",
+		Short: "Restore a terminal item to active status",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			itemID := args[0]
+			path, err := store.FindItem(c.cfg, itemID)
+			if err != nil {
+				return err
+			}
+			item, body, err := store.Read(path)
+			if err != nil {
+				return err
+			}
+			if model.IsActive(item.Status) {
+				return fmt.Errorf("item %q is already active", itemID)
+			}
+			item.Status = model.StatusActive
 			item.UpdatedAt = time.Now()
 			newPath := store.PathForItem(c.cfg, item)
 			return store.Move(path, newPath, item, body)

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -83,6 +83,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 - `htd item list [--kind KIND] [--status STATUS] [--tag TAG] [--project PID]`
 - `htd item update ID FIELD=VALUE...` — `id` and `created_at` are protected.
 - `htd item archive ID`
+- `htd item restore ID` — undo an accidental `engage done`/`cancel`/`discard`/`archive`; brings a terminal item back to `active` and moves it to `items/<kind>/`.
 
 ## Choosing a command
 
@@ -98,6 +99,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 | Chasing a delegated task | `/htd:engage` → drill into waiting |
 | Tickler for date X fires | `/htd:daily-review` (pulls fired ticklers into the inbox, then clarify decides) |
 | Completing a task | `htd engage done ID` (direct call is fine) |
+| "I marked the wrong item done", undo an accidental terminal transition | `htd item restore ID` |
 
 ## Interaction principles
 


### PR DESCRIPTION
## Summary

- New low-level command: `htd item restore ID`.
- Sets `status: active`, refreshes `updated_at`, and moves the file from `archive/items/` back to `items/<kind>/` based on the stored `kind`.
- Explicit, discoverable inverse of `engage done` / `engage cancel` / `clarify discard` / `item archive`. Replaces the previous `htd item update <id> status=active` hack, which only worked as a side effect.
- Errors when the target is already active or missing (exit code 2 for not-found, per existing convention).
- Docs, PRD, data model notes, README, and the workflow skill guidance updated to point error-correction scenarios at `item restore`.

## Test plan

- [x] `mise run test` — unit tests pass, new coverage:
  - restore from `done`, `canceled`, `discarded` (lands back in inbox), `archived`
  - errors when the item is already active
  - errors when the item does not exist (NotFoundError)
  - body preserved and `updated_at` refreshed
  - archive copy removed, file present in the kind directory
- [x] `mise run lint` — clean.

Closes #8