### PR TITLE
docs(cli): document RFC3339 datetime support in --due/--defer

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -261,8 +261,8 @@ htd organize schedule ID [--due DATE] [--defer DATE] [--review DATE]
 | Option | Required | Description |
 |--------|----------|-------------|
 | `--due` | no | Due date (`YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ss±hh:mm`) |
-| `--defer` | no | Defer-until date (item is hidden until this date) |
-| `--review` | no | Next review date |
+| `--defer` | no | Defer-until date (`YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ss±hh:mm`); item is hidden until this moment |
+| `--review` | no | Next review date (`YYYY-MM-DD`) |
 
 **Behavior:**
 
@@ -270,6 +270,8 @@ htd organize schedule ID [--due DATE] [--defer DATE] [--review DATE]
 2. Set `updated_at` to the current timestamp.
 
 At least one date option must be provided. To clear a date, pass `--due ""`.
+
+When a datetime is supplied, it is preserved to the second and `engage next-action` / `reflect next-actions` sort intra-day by the exact moment. A date-only value is interpreted as midnight in the local timezone.
 
 ### 4.4 `htd organize promote`
 
@@ -329,7 +331,7 @@ htd reflect next-actions
 1. Read all files in `items/next_action/` with `status: active`.
 2. Exclude items where `defer_until` is in the future.
 3. Display: `ID`, `TITLE`, `PROJECT`, `DUE_AT`.
-4. Sort by `due_at` ascending (items without due dates last).
+4. Sort by `due_at` ascending (items without due dates last). Datetimes sort by their exact moment; date-only values sort as midnight local time.
 
 ### 5.2 `htd reflect projects`
 
@@ -528,7 +530,7 @@ htd engage next-action [--project PROJECT_ID] [--tag TAG]...
 2. Exclude items where `defer_until` is in the future.
 3. Apply `--project` and `--tag` filters if provided.
 4. Display: `ID`, `TITLE`, `PROJECT`, `DUE_AT`.
-5. Sort by `due_at` ascending (items without due dates last).
+5. Sort by `due_at` ascending (items without due dates last). Datetimes sort by their exact moment; date-only values sort as midnight local time.
 
 This command overlaps with `reflect next-actions` in content; the difference is intent (Engage = pick work; Reflect = review system) plus the filter flags above.
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -397,6 +397,117 @@ func TestOrganizeSchedule(t *testing.T) {
 	}
 }
 
+func TestOrganizeScheduleRFC3339Due(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-rfc_due", model.KindNextAction, model.StatusActive), "")
+
+	const input = "2026-05-01T14:30:00+09:00"
+	_, _, err := runCmd(t, dir, "organize", "schedule", "20260417-rfc_due", "--due", input)
+	if err != nil {
+		t.Fatalf("organize schedule: %v", err)
+	}
+
+	want, err := time.Parse(time.RFC3339, input)
+	if err != nil {
+		t.Fatalf("parse want: %v", err)
+	}
+	got, _ := readItem(t, dir, "20260417-rfc_due")
+	if got.DueAt == nil {
+		t.Fatal("due_at: want non-nil, got nil")
+	}
+	if !got.DueAt.Equal(want) {
+		t.Errorf("due_at: want %s, got %s", want, got.DueAt)
+	}
+
+	cfg := config.New(dir)
+	p := filepath.Join(cfg.DirForKind(model.KindNextAction), "20260417-rfc_due.md")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !strings.Contains(string(raw), input) {
+		t.Errorf("on-disk YAML should preserve RFC3339 string %q, got:\n%s", input, raw)
+	}
+}
+
+func TestOrganizeScheduleRFC3339Defer(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-rfc_defer_future", model.KindNextAction, model.StatusActive), "")
+	writeItem(t, dir, nowItem("20260417-rfc_defer_past", model.KindNextAction, model.StatusActive), "")
+
+	future := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
+	past := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+
+	if _, _, err := runCmd(t, dir, "organize", "schedule", "20260417-rfc_defer_future", "--defer", future); err != nil {
+		t.Fatalf("schedule future defer: %v", err)
+	}
+	if _, _, err := runCmd(t, dir, "organize", "schedule", "20260417-rfc_defer_past", "--defer", past); err != nil {
+		t.Fatalf("schedule past defer: %v", err)
+	}
+
+	got, _ := readItem(t, dir, "20260417-rfc_defer_future")
+	if got.DeferUntil == nil {
+		t.Fatal("defer_until: want non-nil, got nil")
+	}
+	wantFuture, _ := time.Parse(time.RFC3339, future)
+	if !got.DeferUntil.Equal(wantFuture) {
+		t.Errorf("defer_until: want %s, got %s", wantFuture, got.DeferUntil)
+	}
+
+	out, _, err := runCmd(t, dir, "engage", "next-action")
+	if err != nil {
+		t.Fatalf("engage next-action: %v", err)
+	}
+	if strings.Contains(out, "20260417-rfc_defer_future") {
+		t.Errorf("item with defer_until in the future should be hidden: %q", out)
+	}
+	if !strings.Contains(out, "20260417-rfc_defer_past") {
+		t.Errorf("item with defer_until in the past should be visible: %q", out)
+	}
+}
+
+func TestEngageNextActionSortsIntraDay(t *testing.T) {
+	dir := setupDir(t)
+	day := time.Date(2026, 5, 1, 0, 0, 0, 0, time.Local)
+	morning := day.Add(9 * time.Hour)
+	afternoon := day.Add(13 * time.Hour)
+	evening := day.Add(18 * time.Hour)
+
+	e := nowItem("20260501-c_evening", model.KindNextAction, model.StatusActive)
+	e.DueAt = &evening
+	m := nowItem("20260501-a_morning", model.KindNextAction, model.StatusActive)
+	m.DueAt = &morning
+	a := nowItem("20260501-b_afternoon", model.KindNextAction, model.StatusActive)
+	a.DueAt = &afternoon
+	writeItem(t, dir, e, "")
+	writeItem(t, dir, m, "")
+	writeItem(t, dir, a, "")
+
+	out, _, err := runCmd(t, dir, "engage", "next-action")
+	if err != nil {
+		t.Fatalf("engage next-action: %v", err)
+	}
+
+	want := []string{
+		"20260501-a_morning",
+		"20260501-b_afternoon",
+		"20260501-c_evening",
+	}
+	var positions []int
+	for _, id := range want {
+		idx := strings.Index(out, id)
+		if idx < 0 {
+			t.Fatalf("missing %s in output: %q", id, out)
+		}
+		positions = append(positions, idx)
+	}
+	for i := 1; i < len(positions); i++ {
+		if positions[i] < positions[i-1] {
+			t.Errorf("sort order: %s should appear after %s\nout=%q", want[i], want[i-1], out)
+		}
+	}
+}
+
 func TestOrganizePromote(t *testing.T) {
 	dir := setupDir(t)
 	parent := nowItem("20260420-launch_cli", model.KindInbox, model.StatusActive)

--- a/internal/command/organize.go
+++ b/internal/command/organize.go
@@ -169,7 +169,7 @@ func newOrganizeScheduleCommand(c *container) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&due, "due", "", "Due date (YYYY-MM-DD or RFC3339)")
-	cmd.Flags().StringVar(&defer_, "defer", "", "Defer-until date")
+	cmd.Flags().StringVar(&defer_, "defer", "", "Defer-until date (YYYY-MM-DD or RFC3339)")
 	cmd.Flags().StringVar(&review, "review", "", "Next review date")
 	return cmd
 }


### PR DESCRIPTION
## Summary

- Advertise `YYYY-MM-DD` or RFC3339 datetime on `--defer` help text and in `docs/cli.md §4.3` (parity with `--due`, which was already documented).
- Document that `engage next-action` / `reflect next-actions` sort intra-day by the exact datetime.
- Add three tests covering the datetime path: `--due` round-trips RFC3339 in on-disk YAML, `--defer` with a future/past datetime hides/shows correctly in `engage next-action`, and three items on the same date at 09:00 / 13:00 / 18:00 sort in order.

No behavior change — `parseDate` already accepted RFC3339 and the model stores `*time.Time`; this PR formalizes the contract.

Closes #11.

## Test plan

- [x] `mise run test` — all tests pass, including three new cases
- [x] `mise run lint` — clean
- [x] Manual smoke: morning/afternoon/evening items with RFC3339 `--due` sort in order in `engage next-action`; `--defer` to 2099 hides an item; `--defer ""` clears it
- [x] Inspected on-disk `.md` — `due_at` preserved as `2026-04-21T09:00:00+09:00`