### PR TITLE
feat(item): add refs field for external URLs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,7 +65,7 @@ Resolution order for the root directory: `--path` (if given) → `$HTD_PATH` (if
 Add a new item to the inbox.
 
 ```
-htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]... [--done]
+htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]... [--ref URL]... [--done]
 ```
 
 | Option | Required | Description |
@@ -74,6 +74,7 @@ htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]... [--don
 | `--body` | no | Detailed description (Markdown) |
 | `--source` | no | Origin of the item (e.g., `email`, `meeting`, `slack`) |
 | `--tag` | no | Tag to attach; repeatable for multiple tags |
+| `--ref` | no | External reference URL (e.g., PR, ticket, doc); repeatable |
 | `--done` | no | Capture the item as already completed (see below) |
 
 **Behavior:**
@@ -89,6 +90,9 @@ htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]... [--don
 ```
 $ htd capture add --title "Write the man page" --source manual --tag cli --tag docs
 20260417-write_the_man_page
+
+$ htd capture add --title "Review PR #42" --ref https://github.com/foo/bar/pull/42
+20260421-review_pr_42
 ```
 
 **`--done` behavior:**
@@ -101,7 +105,7 @@ When `--done` is passed, the item is captured as already completed instead of en
 4. Write the file directly to `archive/items/<id>.md` (no temporary stop in `items/inbox/`).
 5. Print the created ID to stdout.
 
-`--body`, `--source`, and `--tag` still apply when `--done` is set, so metadata is preserved on the archived item.
+`--body`, `--source`, `--tag`, and `--ref` still apply when `--done` is set, so metadata is preserved on the archived item.
 
 **Example:**
 
@@ -155,13 +159,14 @@ htd clarify show ID
 Update the content of an inbox item.
 
 ```
-htd clarify update ID [--title TEXT] [--body TEXT]
+htd clarify update ID [--title TEXT] [--body TEXT] [--ref URL]...
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
 | `--title` | no | New title |
 | `--body` | no | New body content |
+| `--ref` | no | New reference URL; repeatable. Each invocation of this command replaces the full `refs` list with the supplied values. Pass no `--ref` at all to leave existing refs untouched. |
 
 **Behavior:**
 
@@ -170,7 +175,7 @@ htd clarify update ID [--title TEXT] [--body TEXT]
 3. Set `updated_at` to the current timestamp.
 4. Write the file back.
 
-At least one of `--title` or `--body` must be provided.
+At least one of `--title`, `--body`, or `--ref` must be provided.
 
 ### 3.4 `htd clarify discard`
 
@@ -623,6 +628,7 @@ htd item update ID FIELD=VALUE [FIELD=VALUE]...
 ```
 $ htd item update 20260417-write_the_man_page kind=next_action
 $ htd item update 20260417-write_the_man_page tags='[cli,docs,v1]'
+$ htd item update 20260417-write_the_man_page refs='[https://github.com/foo/bar/pull/42]'
 ```
 
 ### 7.4 `htd item archive`

--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -26,6 +26,7 @@ An Item is the primary data type. It represents any actionable or incomplete pie
 | `review_at` | date | no | yes | Next review date |
 | `source` | string | no | yes | Origin of the item (e.g., `manual`, `email`, `slack`) |
 | `tags` | list of strings | no | yes | Arbitrary tags for filtering |
+| `refs` | list of strings | no | yes | External reference URLs (PRs, tickets, docs, etc.) |
 
 The Markdown body (content after the front matter `---` delimiter) stores the detailed description. This is referred to as `body` in CLI options but is not a front matter field.
 
@@ -192,6 +193,7 @@ updated_at: 2026-04-17T09:30:00+09:00
 review_at: 2026-04-20
 source: manual
 tags: [cli, docs]
+refs: [https://github.com/foo/bar/pull/42]
 ---
 
 Detailed description of the task goes here.

--- a/internal/command/capture.go
+++ b/internal/command/capture.go
@@ -25,6 +25,7 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 		body   string
 		source string
 		tags   []string
+		refs   []string
 		done   bool
 	)
 
@@ -55,11 +56,15 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 				Status:    status,
 				Source:    source,
 				Tags:      tags,
+				Refs:      refs,
 				CreatedAt: now,
 				UpdatedAt: now,
 			}
 			if len(tags) == 0 {
 				item.Tags = nil
+			}
+			if len(refs) == 0 {
+				item.Refs = nil
 			}
 
 			path := store.PathForItem(c.cfg, item)
@@ -75,6 +80,7 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 	cmd.Flags().StringVar(&body, "body", "", "Detailed description (Markdown)")
 	cmd.Flags().StringVar(&source, "source", "", "Origin of the item")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable)")
+	cmd.Flags().StringArrayVar(&refs, "ref", nil, "External reference URL (repeatable)")
 	cmd.Flags().BoolVar(&done, "done", false, "Capture the item as already completed (lands in archive/items/ with kind=next_action, status=done)")
 
 	return cmd

--- a/internal/command/clarify.go
+++ b/internal/command/clarify.go
@@ -69,6 +69,7 @@ func newClarifyUpdateCommand(c *container) *cobra.Command {
 	var (
 		title string
 		body  string
+		refs  []string
 	)
 
 	cmd := &cobra.Command{
@@ -76,8 +77,8 @@ func newClarifyUpdateCommand(c *container) *cobra.Command {
 		Short: "Update an inbox item",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("title") && !cmd.Flags().Changed("body") {
-				return fmt.Errorf("at least one of --title or --body must be provided")
+			if !cmd.Flags().Changed("title") && !cmd.Flags().Changed("body") && !cmd.Flags().Changed("ref") {
+				return fmt.Errorf("at least one of --title, --body, or --ref must be provided")
 			}
 			itemID := args[0]
 			path, err := store.FindItem(c.cfg, itemID)
@@ -97,6 +98,13 @@ func newClarifyUpdateCommand(c *container) *cobra.Command {
 			if cmd.Flags().Changed("body") {
 				existingBody = body
 			}
+			if cmd.Flags().Changed("ref") {
+				if len(refs) == 0 {
+					item.Refs = nil
+				} else {
+					item.Refs = refs
+				}
+			}
 			item.UpdatedAt = time.Now()
 			return store.Write(path, item, existingBody)
 		},
@@ -104,6 +112,7 @@ func newClarifyUpdateCommand(c *container) *cobra.Command {
 
 	cmd.Flags().StringVar(&title, "title", "", "New title")
 	cmd.Flags().StringVar(&body, "body", "", "New body content")
+	cmd.Flags().StringArrayVar(&refs, "ref", nil, "New reference URLs (repeatable; replaces existing refs)")
 	return cmd
 }
 

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -121,6 +121,44 @@ func TestCaptureAddWithOptions(t *testing.T) {
 	}
 }
 
+func TestCaptureAddWithRefs(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "capture", "add",
+		"--title", "Review PR",
+		"--ref", "https://github.com/foo/bar/pull/1",
+		"--ref", "https://notion.so/x",
+	)
+	if err != nil {
+		t.Fatalf("capture add --ref: %v", err)
+	}
+	id := strings.TrimSpace(out)
+	item, _ := readItem(t, dir, id)
+	if len(item.Refs) != 2 {
+		t.Fatalf("refs: want 2, got %d (%v)", len(item.Refs), item.Refs)
+	}
+	if item.Refs[0] != "https://github.com/foo/bar/pull/1" || item.Refs[1] != "https://notion.so/x" {
+		t.Errorf("refs: got %v", item.Refs)
+	}
+}
+
+func TestCaptureAddOmitsRefsWhenAbsent(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "capture", "add", "--title", "No refs")
+	if err != nil {
+		t.Fatalf("capture add: %v", err)
+	}
+	id := strings.TrimSpace(out)
+	cfg := config.New(dir)
+	p := filepath.Join(cfg.DirForKind(model.KindInbox), id+".md")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if strings.Contains(string(data), "refs:") {
+		t.Errorf("expected no refs field in YAML when unset:\n%s", string(data))
+	}
+}
+
 func TestCaptureAddDone(t *testing.T) {
 	dir := setupDir(t)
 	out, _, err := runCmd(t, dir, "capture", "add", "--title", "Quick thing", "--done")
@@ -254,6 +292,45 @@ func TestClarifyUpdate(t *testing.T) {
 	}
 	if gotBody != "new body" {
 		t.Errorf("body: want %q, got %q", "new body", gotBody)
+	}
+}
+
+func TestClarifyUpdateRefs(t *testing.T) {
+	dir := setupDir(t)
+	item := nowItem("20260417-refs_me", model.KindInbox, model.StatusActive)
+	item.Refs = []string{"https://old.example.com/1"}
+	writeItem(t, dir, item, "")
+
+	_, _, err := runCmd(t, dir, "clarify", "update", "20260417-refs_me",
+		"--ref", "https://new.example.com/a",
+		"--ref", "https://new.example.com/b",
+	)
+	if err != nil {
+		t.Fatalf("clarify update --ref: %v", err)
+	}
+
+	got, _ := readItem(t, dir, "20260417-refs_me")
+	if len(got.Refs) != 2 {
+		t.Fatalf("refs: want 2, got %d (%v)", len(got.Refs), got.Refs)
+	}
+	if got.Refs[0] != "https://new.example.com/a" || got.Refs[1] != "https://new.example.com/b" {
+		t.Errorf("refs: got %v", got.Refs)
+	}
+}
+
+func TestClarifyUpdateLeavesRefsUntouched(t *testing.T) {
+	dir := setupDir(t)
+	item := nowItem("20260417-keep_refs", model.KindInbox, model.StatusActive)
+	item.Refs = []string{"https://keep.example.com/"}
+	writeItem(t, dir, item, "")
+
+	_, _, err := runCmd(t, dir, "clarify", "update", "20260417-keep_refs", "--title", "Retitled")
+	if err != nil {
+		t.Fatalf("clarify update --title: %v", err)
+	}
+	got, _ := readItem(t, dir, "20260417-keep_refs")
+	if len(got.Refs) != 1 || got.Refs[0] != "https://keep.example.com/" {
+		t.Errorf("refs: want unchanged, got %v", got.Refs)
 	}
 }
 
@@ -1458,6 +1535,58 @@ func TestItemGet(t *testing.T) {
 	}
 }
 
+func TestItemGetShowsRefsText(t *testing.T) {
+	dir := setupDir(t)
+	item := nowItem("20260417-show_refs", model.KindNextAction, model.StatusActive)
+	item.Refs = []string{"https://example.com/pr/1", "https://notion.so/x"}
+	writeItem(t, dir, item, "")
+
+	out, _, err := runCmd(t, dir, "item", "get", "20260417-show_refs")
+	if err != nil {
+		t.Fatalf("item get: %v", err)
+	}
+	if !strings.Contains(out, "refs:") {
+		t.Errorf("item get missing refs label: %q", out)
+	}
+	if !strings.Contains(out, "https://example.com/pr/1") || !strings.Contains(out, "https://notion.so/x") {
+		t.Errorf("item get missing refs values: %q", out)
+	}
+}
+
+func TestItemGetJSONIncludesRefs(t *testing.T) {
+	dir := setupDir(t)
+	item := nowItem("20260417-json_refs", model.KindNextAction, model.StatusActive)
+	item.Refs = []string{"https://example.com/pr/1", "https://notion.so/x"}
+	writeItem(t, dir, item, "")
+
+	out, _, err := runCmd(t, dir, "--json", "item", "get", "20260417-json_refs")
+	if err != nil {
+		t.Fatalf("item get --json: %v", err)
+	}
+	var got struct {
+		Refs []string `json:"refs"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if len(got.Refs) != 2 || got.Refs[0] != "https://example.com/pr/1" || got.Refs[1] != "https://notion.so/x" {
+		t.Errorf("refs: got %v", got.Refs)
+	}
+}
+
+func TestItemGetJSONOmitsRefsWhenEmpty(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-no_refs", model.KindInbox, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "--json", "item", "get", "20260417-no_refs")
+	if err != nil {
+		t.Fatalf("item get --json: %v", err)
+	}
+	if strings.Contains(out, `"refs"`) {
+		t.Errorf("expected no refs key in JSON when empty: %s", out)
+	}
+}
+
 func TestItemList(t *testing.T) {
 	dir := setupDir(t)
 	writeItem(t, dir, nowItem("20260417-list1", model.KindInbox, model.StatusActive), "")
@@ -1516,6 +1645,36 @@ func TestItemUpdateKindMovesFile(t *testing.T) {
 	got, _ := readItem(t, dir, "20260417-kindchg")
 	if got.Kind != model.KindNextAction {
 		t.Errorf("kind: want next_action, got %q", got.Kind)
+	}
+}
+
+func TestItemUpdateRefsField(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-refset", model.KindNextAction, model.StatusActive), "")
+
+	_, _, err := runCmd(t, dir, "item", "update", "20260417-refset",
+		"refs=[https://a.example, https://b.example, https://c.example]")
+	if err != nil {
+		t.Fatalf("item update refs=[...]: %v", err)
+	}
+	got, _ := readItem(t, dir, "20260417-refset")
+	want := []string{"https://a.example", "https://b.example", "https://c.example"}
+	if len(got.Refs) != len(want) {
+		t.Fatalf("refs: want %d, got %d (%v)", len(want), len(got.Refs), got.Refs)
+	}
+	for i, w := range want {
+		if got.Refs[i] != w {
+			t.Errorf("refs[%d]: want %q, got %q", i, w, got.Refs[i])
+		}
+	}
+
+	_, _, err = runCmd(t, dir, "item", "update", "20260417-refset", "refs=")
+	if err != nil {
+		t.Fatalf("item update refs=: %v", err)
+	}
+	got, _ = readItem(t, dir, "20260417-refset")
+	if len(got.Refs) != 0 {
+		t.Errorf("refs: want empty after clear, got %v", got.Refs)
 	}
 }
 

--- a/internal/command/item.go
+++ b/internal/command/item.go
@@ -170,6 +170,24 @@ func applyField(item *model.Item, body *string, key, value string) error {
 			}
 			item.Tags = tags
 		}
+	case "refs":
+		// Parse YAML flow-style list: [a,b,c] or plain comma-separated
+		v := strings.TrimSpace(value)
+		v = strings.TrimPrefix(v, "[")
+		v = strings.TrimSuffix(v, "]")
+		if v == "" {
+			item.Refs = nil
+		} else {
+			parts := strings.Split(v, ",")
+			refs := make([]string, 0, len(parts))
+			for _, p := range parts {
+				p = strings.TrimSpace(p)
+				if p != "" {
+					refs = append(refs, p)
+				}
+			}
+			item.Refs = refs
+		}
 	case "due_at":
 		t, err := parseDate(value)
 		if err != nil {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -51,4 +51,5 @@ type Item struct {
 	ReviewAt   *time.Time `yaml:"review_at,omitempty"`
 	Source     string    `yaml:"source,omitempty"`
 	Tags       []string  `yaml:"tags,omitempty"`
+	Refs       []string  `yaml:"refs,omitempty"`
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -87,6 +87,7 @@ func TestItemYAMLRoundTrip(t *testing.T) {
 		ReviewAt:    &review,
 		Source:      "manual",
 		Tags:        []string{"cli", "docs"},
+		Refs:        []string{"https://example.com/pr/1", "https://notion.so/x"},
 	}
 
 	data, err := yaml.Marshal(item)
@@ -117,6 +118,9 @@ func TestItemYAMLRoundTrip(t *testing.T) {
 	if len(got.Tags) != 2 || got.Tags[0] != "cli" || got.Tags[1] != "docs" {
 		t.Errorf("Tags: want [cli docs], got %v", got.Tags)
 	}
+	if len(got.Refs) != 2 || got.Refs[0] != "https://example.com/pr/1" || got.Refs[1] != "https://notion.so/x" {
+		t.Errorf("Refs: want [https://example.com/pr/1 https://notion.so/x], got %v", got.Refs)
+	}
 	if got.DueAt == nil {
 		t.Error("DueAt: want non-nil, got nil")
 	}
@@ -144,7 +148,7 @@ func TestItemYAMLOmitsNilOptionalFields(t *testing.T) {
 	}
 
 	s := string(data)
-	for _, field := range []string{"due_at", "defer_until", "review_at", "project", "source", "tags"} {
+	for _, field := range []string{"due_at", "defer_until", "review_at", "project", "source", "tags", "refs"} {
 		if contains(s, field+":") {
 			t.Errorf("YAML contains %q field but it should be omitted", field)
 		}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -127,6 +127,9 @@ func (p *Printer) printItemText(item *model.Item, body string) {
 	if len(item.Tags) > 0 {
 		fmt.Fprintf(p.out, "tags:       %v\n", item.Tags)
 	}
+	if len(item.Refs) > 0 {
+		fmt.Fprintf(p.out, "refs:       %v\n", item.Refs)
+	}
 	if body != "" {
 		fmt.Fprintf(p.out, "\n%s\n", body)
 	}
@@ -209,6 +212,7 @@ type itemJSON struct {
 	ReviewAt   string    `json:"review_at,omitempty"`
 	Source     string    `json:"source,omitempty"`
 	Tags       []string  `json:"tags,omitempty"`
+	Refs       []string  `json:"refs,omitempty"`
 	Body       string    `json:"body,omitempty"`
 }
 
@@ -223,6 +227,7 @@ func toItemJSON(item *model.Item, body string) itemJSON {
 		UpdatedAt: item.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		Source:    item.Source,
 		Tags:      item.Tags,
+		Refs:      item.Refs,
 		Body:      body,
 	}
 	if item.DueAt != nil {


### PR DESCRIPTION
## Summary

- Add a first-class `refs: [url, ...]` front matter field to Item so external URLs (PRs, tickets, docs) are structured rather than buried in the Markdown body.
- Wire `--ref` (repeatable) through `capture add` and `clarify update` (replace-semantics), and support `refs=[a,b,c]` / `refs=` in `item update`.
- Render `refs` in text detail views and include it in `--json` output (`omitempty`).
- The `--ref-contains` filter sketched in #12 is intentionally deferred — a per-field filter would grow into a family of `--*-contains` flags, so it should land alongside a unified query design in a separate PR.

Closes #12.

## Test plan

- [x] `mise run test` — all tests green, including 7 new cases (capture set/omit, clarify update replace/leave-untouched, item update set/clear, item get text/JSON with and without refs)
- [x] `mise run lint` — clean
- [x] `mise run build` — binary builds
- [x] Manual smoke test: `capture add --ref ... --ref ...`, `item get`, `item get --json`, `clarify update --ref` (replace), `item update refs=` (clear) — all behave as documented

## Docs

- `docs/cli.md` §2.1 / §3.3 / §7.3 updated with `--ref` / `refs=...`
- `docs/datamodel.md` §2.1 field table and §5.1 example front matter updated