### PR TITLE
feat(query): add minimal query DSL for item list

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -586,7 +586,7 @@ htd item get ID
 List items with optional filters.
 
 ```
-htd item list [--kind KIND] [--status STATUS] [--tag TAG] [--project PROJECT_ID]
+htd item list [--kind KIND] [--status STATUS] [--tag TAG] [--project PROJECT_ID] [--query EXPR]
 ```
 
 | Option | Required | Description |
@@ -595,12 +595,92 @@ htd item list [--kind KIND] [--status STATUS] [--tag TAG] [--project PROJECT_ID]
 | `--status` | no | Filter by status (default: `active`) |
 | `--tag` | no | Filter by tag; repeatable |
 | `--project` | no | Filter by project ID |
+| `--query` | no | Filter with a query expression (see §7.2.1) |
 
 **Behavior:**
 
 1. Scan the appropriate directories based on filters.
 2. If `--status` includes non-active statuses, also scan `archive/items/`.
-3. Display: `ID`, `TITLE`, `KIND`, `STATUS`, `UPDATED_AT`.
+3. If `--query` is given, parse the expression and keep only items that
+   match. The query is AND-combined with the other filters above.
+4. Display: `ID`, `TITLE`, `KIND`, `STATUS`, `UPDATED_AT`.
+
+#### 7.2.1 Query expressions
+
+`--query` accepts a small DSL for filtering items. It composes with the
+other flags with AND: items must pass both the flag filters and the
+query.
+
+**Grammar**
+
+```
+query      := orExpr
+orExpr     := andExpr { OR andExpr }
+andExpr    := unaryExpr { unaryExpr }      // implicit AND by juxtaposition
+unaryExpr  := [NOT | "-"] primary
+primary    := term | "(" query ")"
+term       := [field ":"] value
+value      := bareword | "quoted string"
+```
+
+- Space between terms means AND. Explicit `AND` is also accepted.
+- `OR` chooses either side. `AND` binds tighter than `OR`.
+- `NOT` (or a leading `-`) negates the following primary only. To negate a
+  compound, wrap it in parentheses: `NOT (a b)`.
+- Quoted values allow whitespace and support `\"` and `\\` as the only
+  escapes.
+
+**Fields (whitelist)**
+
+`id`, `title`, `body`, `kind`, `status`, `project`, `source`, `tag`, `ref`.
+
+`tag` and `ref` are singular (matching the `--tag` / `--ref` flags) and
+map to the `tags` and `refs` arrays — a term matches if any element of
+the array contains the needle. Unknown fields are a parse error.
+
+Without a field, the needle is searched across `title`, `body`, `tags`,
+`refs`, `source`, `project`, and `id`. `kind` and `status` are not
+searched unfielded (use `kind:` or `status:` explicitly).
+
+**Matching**
+
+- Default operator is case-insensitive substring match.
+- Date fields (`due_at`, `defer_until`, `review_at`, `created_at`,
+  `updated_at`) are not searchable in v1.
+- URL values that contain `:` (e.g., `https://…`) must be quoted:
+  `ref:"https://github.com/foo/bar"`. Short hostname matches work
+  unquoted: `ref:github.com`.
+
+**Composition notes**
+
+- The default `--status active` still applies. To search across
+  terminated items, pass `--status ''` or an explicit status (e.g.,
+  `--status done`) alongside `--query`. The query itself does not
+  expand the scan into the archive.
+- `--query ''` (empty string) matches every item — convenient for
+  shell scripts that build the query from a variable.
+- Invalid expressions exit with code `1` and an error on stderr.
+
+**Examples**
+
+```
+# Substring search across all fields
+htd item list --query 'panic'
+
+# Fielded match
+htd item list --query 'title:"fix panic"'
+htd item list --query 'ref:github.com'
+
+# Boolean composition
+htd item list --query 'ref:github.com OR ref:notion.so'
+htd item list --query '(ref:github.com OR ref:notion.so) tag:bug'
+
+# Negation
+htd item list --query '-status:done title:"refactor"'
+
+# Compose with flags (AND)
+htd item list --kind next_action --query 'tag:bug'
+```
 
 ### 7.3 `htd item update`
 
@@ -770,7 +850,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd engage next-action` | List next actions ready to work on now |
 | `htd engage waiting` | List waiting-for items that need follow-up |
 | `htd item get ID` | Get any item by ID |
-| `htd item list` | List items with filters |
+| `htd item list` | List items with filters (supports `--query` DSL) |
 | `htd item update ID` | Update item fields directly |
 | `htd item archive ID` | Archive an item (last resort) |
 | `htd item restore ID` | Restore a terminal item to active status |

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1618,6 +1618,192 @@ func TestItemListFilterKind(t *testing.T) {
 	}
 }
 
+func TestItemListQueryUnfielded(t *testing.T) {
+	dir := setupDir(t)
+	a := nowItem("20260417-fix_panic", model.KindInbox, model.StatusActive)
+	a.Title = "Fix panic in parser"
+	b := nowItem("20260417-write_docs", model.KindInbox, model.StatusActive)
+	b.Title = "Write query docs"
+	writeItem(t, dir, a, "")
+	writeItem(t, dir, b, "")
+
+	out, _, err := runCmd(t, dir, "item", "list", "--query", "panic")
+	if err != nil {
+		t.Fatalf("item list --query: %v", err)
+	}
+	if !strings.Contains(out, "20260417-fix_panic") {
+		t.Errorf("expected fix_panic in output: %q", out)
+	}
+	if strings.Contains(out, "20260417-write_docs") {
+		t.Errorf("unexpected write_docs in output: %q", out)
+	}
+}
+
+func TestItemListQueryFieldedTitleQuoted(t *testing.T) {
+	dir := setupDir(t)
+	a := nowItem("20260417-fix_parser_panic", model.KindInbox, model.StatusActive)
+	a.Title = "Fix parser panic"
+	b := nowItem("20260417-refactor_parser", model.KindInbox, model.StatusActive)
+	b.Title = "Refactor parser"
+	writeItem(t, dir, a, "")
+	writeItem(t, dir, b, "")
+
+	out, _, err := runCmd(t, dir, "item", "list", "--query", `title:"fix parser"`)
+	if err != nil {
+		t.Fatalf("item list --query: %v", err)
+	}
+	if !strings.Contains(out, "20260417-fix_parser_panic") {
+		t.Errorf("expected fix_parser_panic in output: %q", out)
+	}
+	if strings.Contains(out, "20260417-refactor_parser") {
+		t.Errorf("unexpected refactor_parser in output: %q", out)
+	}
+}
+
+func TestItemListQueryUnfieldedMatchesBody(t *testing.T) {
+	dir := setupDir(t)
+	a := nowItem("20260417-body_hit", model.KindInbox, model.StatusActive)
+	a.Title = "Task A"
+	b := nowItem("20260417-body_miss", model.KindInbox, model.StatusActive)
+	b.Title = "Task B"
+	writeItem(t, dir, a, "Reproduces on macOS during startup.")
+	writeItem(t, dir, b, "Not relevant.")
+
+	out, _, err := runCmd(t, dir, "item", "list", "--query", "macos")
+	if err != nil {
+		t.Fatalf("item list --query: %v", err)
+	}
+	if !strings.Contains(out, "20260417-body_hit") {
+		t.Errorf("expected body_hit in output: %q", out)
+	}
+	if strings.Contains(out, "20260417-body_miss") {
+		t.Errorf("unexpected body_miss in output: %q", out)
+	}
+}
+
+func TestItemListQueryTagArrayAny(t *testing.T) {
+	dir := setupDir(t)
+	a := nowItem("20260417-bug_item", model.KindInbox, model.StatusActive)
+	a.Tags = []string{"cli", "docs"}
+	writeItem(t, dir, a, "")
+
+	out, _, err := runCmd(t, dir, "item", "list", "--query", "tag:do")
+	if err != nil {
+		t.Fatalf("item list --query: %v", err)
+	}
+	if !strings.Contains(out, "20260417-bug_item") {
+		t.Errorf("expected bug_item (tags contain 'docs') in output: %q", out)
+	}
+}
+
+func TestItemListQueryRefArrayAny(t *testing.T) {
+	dir := setupDir(t)
+	a := nowItem("20260417-ref_hit", model.KindInbox, model.StatusActive)
+	a.Refs = []string{"https://github.com/foo/bar/pull/42"}
+	b := nowItem("20260417-ref_miss", model.KindInbox, model.StatusActive)
+	b.Refs = []string{"https://notion.so/xyz"}
+	writeItem(t, dir, a, "")
+	writeItem(t, dir, b, "")
+
+	out, _, err := runCmd(t, dir, "item", "list", "--query", "ref:github.com")
+	if err != nil {
+		t.Fatalf("item list --query: %v", err)
+	}
+	if !strings.Contains(out, "20260417-ref_hit") {
+		t.Errorf("expected ref_hit in output: %q", out)
+	}
+	if strings.Contains(out, "20260417-ref_miss") {
+		t.Errorf("unexpected ref_miss in output: %q", out)
+	}
+}
+
+func TestItemListQueryBooleanWithExplicitStatus(t *testing.T) {
+	dir := setupDir(t)
+	a := nowItem("20260417-bug_active", model.KindInbox, model.StatusActive)
+	a.Tags = []string{"bug"}
+	b := nowItem("20260417-cli_done", model.KindNextAction, model.StatusDone)
+	b.Tags = []string{"cli"}
+	c := nowItem("20260417-bug_done", model.KindNextAction, model.StatusDone)
+	c.Tags = []string{"bug"}
+	writeItem(t, dir, a, "")
+	writeItem(t, dir, b, "")
+	writeItem(t, dir, c, "")
+
+	// (tag:bug OR tag:cli) NOT status:done — across all statuses.
+	out, _, err := runCmd(t, dir, "item", "list",
+		"--status", "", // disable default status=active so archive is scanned
+		"--query", "(tag:bug OR tag:cli) NOT status:done")
+	if err != nil {
+		t.Fatalf("item list --query: %v", err)
+	}
+	if !strings.Contains(out, "20260417-bug_active") {
+		t.Errorf("expected bug_active in output: %q", out)
+	}
+	if strings.Contains(out, "20260417-cli_done") || strings.Contains(out, "20260417-bug_done") {
+		t.Errorf("unexpected done items in output: %q", out)
+	}
+}
+
+func TestItemListQueryComposesWithFlags(t *testing.T) {
+	dir := setupDir(t)
+	a := nowItem("20260417-inbox_foo", model.KindInbox, model.StatusActive)
+	a.Title = "foo in inbox"
+	b := nowItem("20260417-next_foo", model.KindNextAction, model.StatusActive)
+	b.Title = "foo in next"
+	writeItem(t, dir, a, "")
+	writeItem(t, dir, b, "")
+
+	out, _, err := runCmd(t, dir, "item", "list", "--kind", "inbox", "--query", "foo")
+	if err != nil {
+		t.Fatalf("item list --kind --query: %v", err)
+	}
+	if !strings.Contains(out, "20260417-inbox_foo") {
+		t.Errorf("expected inbox_foo in output: %q", out)
+	}
+	if strings.Contains(out, "20260417-next_foo") {
+		t.Errorf("unexpected next_foo (filtered out by --kind): %q", out)
+	}
+}
+
+func TestItemListQueryEmptyMatchesAll(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-list1", model.KindInbox, model.StatusActive), "")
+	writeItem(t, dir, nowItem("20260417-list2", model.KindNextAction, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "item", "list", "--query", "")
+	if err != nil {
+		t.Fatalf("item list --query '': %v", err)
+	}
+	if !strings.Contains(out, "20260417-list1") || !strings.Contains(out, "20260417-list2") {
+		t.Errorf("expected both items with empty --query: %q", out)
+	}
+}
+
+func TestItemListQueryInvalidExpression(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-any", model.KindInbox, model.StatusActive), "")
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"unterminated quote", `title:"oops`},
+		{"unknown field", "nope:foo"},
+		{"trailing operator", "foo OR"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, _, err := runCmd(t, dir, "item", "list", "--query", c.query)
+			if err == nil {
+				t.Fatalf("expected error for invalid query %q", c.query)
+			}
+			if !strings.Contains(err.Error(), "invalid --query") {
+				t.Errorf("expected 'invalid --query' in error, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestItemUpdate(t *testing.T) {
 	dir := setupDir(t)
 	writeItem(t, dir, nowItem("20260417-upd", model.KindInbox, model.StatusActive), "")

--- a/internal/command/item.go
+++ b/internal/command/item.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/takai/htd/internal/model"
+	"github.com/takai/htd/internal/query"
 	"github.com/takai/htd/internal/store"
 )
 
@@ -52,6 +53,7 @@ func newItemListCommand(c *container) *cobra.Command {
 		statusStr string
 		tag       string
 		projectID string
+		queryStr  string
 	)
 
 	cmd := &cobra.Command{
@@ -77,9 +79,28 @@ func newItemListCommand(c *container) *cobra.Command {
 				f.Status = &s
 			}
 
-			items, err := store.List(c.cfg, f)
+			if queryStr == "" {
+				items, err := store.List(c.cfg, f)
+				if err != nil {
+					return err
+				}
+				c.printer.PrintItems(items)
+				return nil
+			}
+
+			q, err := query.Parse(queryStr)
+			if err != nil {
+				return fmt.Errorf("invalid --query: %w", err)
+			}
+			results, err := store.ListWithBody(c.cfg, f)
 			if err != nil {
 				return err
+			}
+			items := make([]*model.Item, 0, len(results))
+			for _, r := range results {
+				if q.Match(r.Item, r.Body) {
+					items = append(items, r.Item)
+				}
 			}
 			c.printer.PrintItems(items)
 			return nil
@@ -90,6 +111,7 @@ func newItemListCommand(c *container) *cobra.Command {
 	cmd.Flags().StringVar(&statusStr, "status", "", "Filter by status (default: active)")
 	cmd.Flags().StringVar(&tag, "tag", "", "Filter by tag")
 	cmd.Flags().StringVar(&projectID, "project", "", "Filter by project ID")
+	cmd.Flags().StringVar(&queryStr, "query", "", "Filter with query expression (see docs/cli.md §7.2.1)")
 	return cmd
 }
 

--- a/internal/query/ast.go
+++ b/internal/query/ast.go
@@ -1,0 +1,204 @@
+package query
+
+import (
+	"strings"
+
+	"github.com/takai/htd/internal/model"
+)
+
+// Node is a sealed AST node interface.
+type Node interface {
+	eval(ctx *evalCtx) bool
+	isNode()
+}
+
+// AndNode matches when both children match.
+type AndNode struct{ L, R Node }
+
+// OrNode matches when either child matches.
+type OrNode struct{ L, R Node }
+
+// NotNode matches when its child does not.
+type NotNode struct{ X Node }
+
+// TermNode matches a single needle against one or more fields. Field == ""
+// means unfielded: the needle is searched across the unfielded-field set.
+// Needle is always lowercased at parse time for case-insensitive matching.
+type TermNode struct {
+	Field  string
+	Needle string
+}
+
+func (*AndNode) isNode()  {}
+func (*OrNode) isNode()   {}
+func (*NotNode) isNode()  {}
+func (*TermNode) isNode() {}
+
+// evalCtx carries per-item state for a single Match call. Lowercase views
+// of the item's string fields are computed lazily on first access and
+// cached so multi-term queries don't re-lowercase.
+type evalCtx struct {
+	item *model.Item
+	body string
+
+	lcTitle, lcBody, lcProject, lcSource, lcID, lcKind, lcStatus string
+	lcTags, lcRefs                                               []string
+
+	titleReady, bodyReady, projectReady, sourceReady, idReady, kindReady, statusReady bool
+	tagsReady, refsReady                                                              bool
+}
+
+func (c *evalCtx) title() string {
+	if !c.titleReady {
+		c.lcTitle = strings.ToLower(c.item.Title)
+		c.titleReady = true
+	}
+	return c.lcTitle
+}
+
+func (c *evalCtx) bodyLC() string {
+	if !c.bodyReady {
+		c.lcBody = strings.ToLower(c.body)
+		c.bodyReady = true
+	}
+	return c.lcBody
+}
+
+func (c *evalCtx) project() string {
+	if !c.projectReady {
+		c.lcProject = strings.ToLower(c.item.Project)
+		c.projectReady = true
+	}
+	return c.lcProject
+}
+
+func (c *evalCtx) source() string {
+	if !c.sourceReady {
+		c.lcSource = strings.ToLower(c.item.Source)
+		c.sourceReady = true
+	}
+	return c.lcSource
+}
+
+func (c *evalCtx) id() string {
+	if !c.idReady {
+		c.lcID = strings.ToLower(c.item.ID)
+		c.idReady = true
+	}
+	return c.lcID
+}
+
+func (c *evalCtx) kind() string {
+	if !c.kindReady {
+		c.lcKind = strings.ToLower(string(c.item.Kind))
+		c.kindReady = true
+	}
+	return c.lcKind
+}
+
+func (c *evalCtx) status() string {
+	if !c.statusReady {
+		c.lcStatus = strings.ToLower(string(c.item.Status))
+		c.statusReady = true
+	}
+	return c.lcStatus
+}
+
+func (c *evalCtx) tags() []string {
+	if !c.tagsReady {
+		c.lcTags = lowerSlice(c.item.Tags)
+		c.tagsReady = true
+	}
+	return c.lcTags
+}
+
+func (c *evalCtx) refs() []string {
+	if !c.refsReady {
+		c.lcRefs = lowerSlice(c.item.Refs)
+		c.refsReady = true
+	}
+	return c.lcRefs
+}
+
+func lowerSlice(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = strings.ToLower(s)
+	}
+	return out
+}
+
+func (n *AndNode) eval(ctx *evalCtx) bool {
+	return n.L.eval(ctx) && n.R.eval(ctx)
+}
+
+func (n *OrNode) eval(ctx *evalCtx) bool {
+	return n.L.eval(ctx) || n.R.eval(ctx)
+}
+
+func (n *NotNode) eval(ctx *evalCtx) bool {
+	return !n.X.eval(ctx)
+}
+
+func (n *TermNode) eval(ctx *evalCtx) bool {
+	switch n.Field {
+	case "":
+		return ctx.matchUnfielded(n.Needle)
+	case "title":
+		return strings.Contains(ctx.title(), n.Needle)
+	case "body":
+		return strings.Contains(ctx.bodyLC(), n.Needle)
+	case "project":
+		return strings.Contains(ctx.project(), n.Needle)
+	case "source":
+		return strings.Contains(ctx.source(), n.Needle)
+	case "id":
+		return strings.Contains(ctx.id(), n.Needle)
+	case "kind":
+		return strings.Contains(ctx.kind(), n.Needle)
+	case "status":
+		return strings.Contains(ctx.status(), n.Needle)
+	case "tag":
+		return anyContains(ctx.tags(), n.Needle)
+	case "ref":
+		return anyContains(ctx.refs(), n.Needle)
+	}
+	return false
+}
+
+func (ctx *evalCtx) matchUnfielded(needle string) bool {
+	if strings.Contains(ctx.title(), needle) {
+		return true
+	}
+	if strings.Contains(ctx.bodyLC(), needle) {
+		return true
+	}
+	if strings.Contains(ctx.id(), needle) {
+		return true
+	}
+	if ctx.item.Project != "" && strings.Contains(ctx.project(), needle) {
+		return true
+	}
+	if ctx.item.Source != "" && strings.Contains(ctx.source(), needle) {
+		return true
+	}
+	if anyContains(ctx.tags(), needle) {
+		return true
+	}
+	if anyContains(ctx.refs(), needle) {
+		return true
+	}
+	return false
+}
+
+func anyContains(haystacks []string, needle string) bool {
+	for _, h := range haystacks {
+		if strings.Contains(h, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/query/ast_test.go
+++ b/internal/query/ast_test.go
@@ -1,0 +1,121 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/takai/htd/internal/model"
+)
+
+func fixtureItem() *model.Item {
+	return &model.Item{
+		ID:      "20260421-fix_parser_panic",
+		Title:   "Fix parser panic",
+		Kind:    model.KindNextAction,
+		Status:  model.StatusActive,
+		Project: "launch_cli",
+		Source:  "email",
+		Tags:    []string{"bug", "cli"},
+		Refs:    []string{"https://github.com/foo/bar/pull/42"},
+	}
+}
+
+const fixtureBody = "Reproduces on macOS during startup."
+
+func TestMatch(t *testing.T) {
+	item := fixtureItem()
+	cases := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"empty matches all", "", true},
+		{"unfielded hits title", "parser", true},
+		{"unfielded hits body", "macos", true},
+		{"unfielded hits id", "20260421", true},
+		{"unfielded hits tag element", "bug", true},
+		{"unfielded hits ref element", "github.com", true},
+		{"unfielded hits source", "email", true},
+		{"unfielded hits project", "launch", true},
+		{"unfielded misses unrelated", "nonsense_xyz", false},
+		{"unfielded does not match kind enum", "next_action", false},
+		{"unfielded does not match status enum", "active", false},
+		{"case insensitive unfielded", "PARSER", true},
+		{"fielded title hit", "title:parser", true},
+		{"fielded title miss", "title:nonsense", false},
+		{"fielded title quoted", `title:"fix parser"`, true},
+		{"fielded body hit", "body:macOS", true},
+		{"fielded body miss", "body:nonsense", false},
+		{"fielded kind substring", "kind:next", true},
+		{"fielded kind exact", "kind:next_action", true},
+		{"fielded kind miss", "kind:project", false},
+		{"fielded status hit", "status:active", true},
+		{"fielded status miss", "status:done", false},
+		{"fielded project hit", "project:launch_cli", true},
+		{"fielded project miss", "project:other", false},
+		{"fielded source hit", "source:email", true},
+		{"fielded tag any element", "tag:bug", true},
+		{"fielded tag substring of element", "tag:cl", true},
+		{"fielded tag miss", "tag:other", false},
+		{"fielded ref any element", "ref:github.com", true},
+		{"fielded ref quoted URL", `ref:"https://github.com"`, true},
+		{"fielded ref miss", "ref:notion.so", false},
+		{"fielded id hit", "id:fix_parser", true},
+		{"AND both true", "parser body:macos", true},
+		{"AND one false", "parser body:nonsense", false},
+		{"OR either true", "nonsense OR parser", true},
+		{"OR both false", "nonsense OR xyzzy", false},
+		{"NOT flips", "NOT parser", false},
+		{"NOT of miss is true", "NOT nonsense", true},
+		{"dash NOT flips", "-parser", false},
+		{"parens grouping", "(nonsense OR parser) tag:bug", true},
+		{"parens grouping false", "(nonsense OR xyzzy) tag:bug", false},
+		{"issue-style compound",
+			"(ref:github.com OR ref:notion.so) tag:bug", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			q, err := Parse(c.query)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", c.query, err)
+			}
+			got := q.Match(item, fixtureBody)
+			if got != c.want {
+				t.Errorf("Match(%q) = %v, want %v", c.query, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMatchEmptyFields(t *testing.T) {
+	// Item with sparse fields: no project, no source, empty tags/refs.
+	item := &model.Item{
+		ID:     "20260421-x",
+		Title:  "x",
+		Kind:   model.KindInbox,
+		Status: model.StatusActive,
+	}
+	cases := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"unfielded does not falsely hit empty project", "nonsense", false},
+		{"fielded project miss on empty", "project:foo", false},
+		{"fielded source miss on empty", "source:foo", false},
+		{"fielded tag miss on empty", "tag:foo", false},
+		{"fielded ref miss on empty", "ref:foo", false},
+		{"NOT of miss on empty is true", "NOT project:foo", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			q, err := Parse(c.query)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", c.query, err)
+			}
+			got := q.Match(item, "")
+			if got != c.want {
+				t.Errorf("Match(%q) = %v, want %v", c.query, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/query/lexer.go
+++ b/internal/query/lexer.go
@@ -1,0 +1,123 @@
+package query
+
+import (
+	"strings"
+)
+
+type tokenKind int
+
+const (
+	tokEOF tokenKind = iota
+	tokLParen
+	tokRParen
+	tokColon
+	tokAnd
+	tokOr
+	tokNot
+	tokWord
+	tokQuoted
+)
+
+type token struct {
+	kind  tokenKind
+	value string
+	pos   int
+}
+
+// lex tokenizes the input query string. Whitespace is a separator but
+// produces no token; juxtaposition between tokens is implicit AND. The
+// reserved words AND/OR/NOT (case-insensitive) and a leading "-" become
+// dedicated tokens.
+func lex(input string) ([]token, error) {
+	var out []token
+	i := 0
+	for i < len(input) {
+		c := input[i]
+		if isSpace(c) {
+			i++
+			continue
+		}
+		switch c {
+		case '(':
+			out = append(out, token{kind: tokLParen, value: "(", pos: i})
+			i++
+		case ')':
+			out = append(out, token{kind: tokRParen, value: ")", pos: i})
+			i++
+		case ':':
+			out = append(out, token{kind: tokColon, value: ":", pos: i})
+			i++
+		case '"':
+			t, next, err := scanQuoted(input, i)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, t)
+			i = next
+		case '-':
+			out = append(out, token{kind: tokNot, value: "-", pos: i})
+			i++
+		default:
+			t, next := scanWord(input, i)
+			out = append(out, t)
+			i = next
+		}
+	}
+	out = append(out, token{kind: tokEOF, value: "", pos: i})
+	return out, nil
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func isWordBoundary(c byte) bool {
+	return isSpace(c) || c == '(' || c == ')' || c == ':' || c == '"'
+}
+
+// scanQuoted consumes `"..."` starting at input[start] (which must be `"`).
+// Supports \" and \\ escapes. Returns the token (kind=tokQuoted, value=
+// unescaped contents, pos=start) and the next index (one past the closing
+// quote). An unterminated quote yields a *ParseError at the opening quote.
+func scanQuoted(input string, start int) (token, int, error) {
+	var sb strings.Builder
+	i := start + 1
+	for i < len(input) {
+		c := input[i]
+		if c == '\\' && i+1 < len(input) {
+			n := input[i+1]
+			if n == '"' || n == '\\' {
+				sb.WriteByte(n)
+				i += 2
+				continue
+			}
+		}
+		if c == '"' {
+			return token{kind: tokQuoted, value: sb.String(), pos: start}, i + 1, nil
+		}
+		sb.WriteByte(c)
+		i++
+	}
+	return token{}, 0, &ParseError{Pos: start, Msg: "unterminated quoted string"}
+}
+
+// scanWord consumes a bareword starting at input[start]. A bareword runs
+// until whitespace, a paren, a colon, or a quote. If the bareword matches
+// a reserved keyword (AND/OR/NOT, case-insensitive), the corresponding
+// reserved token is emitted with the original case preserved in value.
+func scanWord(input string, start int) (token, int) {
+	i := start
+	for i < len(input) && !isWordBoundary(input[i]) {
+		i++
+	}
+	lit := input[start:i]
+	switch strings.ToUpper(lit) {
+	case "AND":
+		return token{kind: tokAnd, value: lit, pos: start}, i
+	case "OR":
+		return token{kind: tokOr, value: lit, pos: start}, i
+	case "NOT":
+		return token{kind: tokNot, value: lit, pos: start}, i
+	}
+	return token{kind: tokWord, value: lit, pos: start}, i
+}

--- a/internal/query/lexer_test.go
+++ b/internal/query/lexer_test.go
@@ -1,0 +1,115 @@
+package query
+
+import (
+	"errors"
+	"testing"
+)
+
+type tok struct {
+	kind  tokenKind
+	value string
+}
+
+func lexToks(t *testing.T, input string) []tok {
+	t.Helper()
+	toks, err := lex(input)
+	if err != nil {
+		t.Fatalf("lex(%q) unexpected error: %v", input, err)
+	}
+	out := make([]tok, 0, len(toks))
+	for _, x := range toks {
+		out = append(out, tok{x.kind, x.value})
+	}
+	return out
+}
+
+func TestLex(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []tok
+	}{
+		{"empty", "", []tok{{tokEOF, ""}}},
+		{"whitespace only", "   \t  ", []tok{{tokEOF, ""}}},
+		{"single word", "foo", []tok{{tokWord, "foo"}, {tokEOF, ""}}},
+		{"surrounding whitespace trimmed", "  foo  ", []tok{{tokWord, "foo"}, {tokEOF, ""}}},
+		{"two words", "foo bar", []tok{{tokWord, "foo"}, {tokWord, "bar"}, {tokEOF, ""}}},
+		{"parens", "(a b)", []tok{
+			{tokLParen, "("}, {tokWord, "a"}, {tokWord, "b"}, {tokRParen, ")"}, {tokEOF, ""},
+		}},
+		{"colon fielded", "title:foo", []tok{
+			{tokWord, "title"}, {tokColon, ":"}, {tokWord, "foo"}, {tokEOF, ""},
+		}},
+		{"quoted simple", `"fix panic"`, []tok{{tokQuoted, "fix panic"}, {tokEOF, ""}}},
+		{"quoted with escape quote", `"a\"b"`, []tok{{tokQuoted, `a"b`}, {tokEOF, ""}}},
+		{"quoted with escape backslash", `"a\\b"`, []tok{{tokQuoted, `a\b`}, {tokEOF, ""}}},
+		{"field quoted", `title:"fix panic"`, []tok{
+			{tokWord, "title"}, {tokColon, ":"}, {tokQuoted, "fix panic"}, {tokEOF, ""},
+		}},
+		{"OR reserved uppercase", "a OR b", []tok{
+			{tokWord, "a"}, {tokOr, "OR"}, {tokWord, "b"}, {tokEOF, ""},
+		}},
+		{"or reserved lowercase", "a or b", []tok{
+			{tokWord, "a"}, {tokOr, "or"}, {tokWord, "b"}, {tokEOF, ""},
+		}},
+		{"NOT reserved", "NOT a", []tok{{tokNot, "NOT"}, {tokWord, "a"}, {tokEOF, ""}}},
+		{"AND reserved", "a AND b", []tok{
+			{tokWord, "a"}, {tokAnd, "AND"}, {tokWord, "b"}, {tokEOF, ""},
+		}},
+		{"leading dash is NOT", "-foo", []tok{{tokNot, "-"}, {tokWord, "foo"}, {tokEOF, ""}}},
+		{"intraword dash preserved", "20260417-foo", []tok{
+			{tokWord, "20260417-foo"}, {tokEOF, ""},
+		}},
+		{"dash before field", "-tag:bug", []tok{
+			{tokNot, "-"}, {tokWord, "tag"}, {tokColon, ":"}, {tokWord, "bug"}, {tokEOF, ""},
+		}},
+		{"nested NOT with group", "NOT (a OR b)", []tok{
+			{tokNot, "NOT"}, {tokLParen, "("}, {tokWord, "a"}, {tokOr, "OR"}, {tokWord, "b"}, {tokRParen, ")"}, {tokEOF, ""},
+		}},
+		{"ref value is a URL bareword", "ref:github.com", []tok{
+			{tokWord, "ref"}, {tokColon, ":"}, {tokWord, "github.com"}, {tokEOF, ""},
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := lexToks(t, c.input)
+			if len(got) != len(c.want) {
+				t.Fatalf("lex(%q) got %d tokens, want %d: got=%v want=%v",
+					c.input, len(got), len(c.want), got, c.want)
+			}
+			for i, w := range c.want {
+				if got[i].kind != w.kind || got[i].value != w.value {
+					t.Errorf("token[%d] = {kind=%d value=%q}, want {kind=%d value=%q}",
+						i, got[i].kind, got[i].value, w.kind, w.value)
+				}
+			}
+		})
+	}
+}
+
+func TestLexError(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantPos int
+	}{
+		{"unterminated quote", `"foo`, 0},
+		{"unterminated quote after escape", `"a\"b`, 0},
+		{"unterminated quote mid input", `foo "bar`, 4},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := lex(c.input)
+			if err == nil {
+				t.Fatalf("lex(%q) expected error, got nil", c.input)
+			}
+			var pe *ParseError
+			if !errors.As(err, &pe) {
+				t.Fatalf("expected *ParseError, got %T: %v", err, err)
+			}
+			if pe.Pos != c.wantPos {
+				t.Errorf("err.Pos = %d, want %d (err=%v)", pe.Pos, c.wantPos, pe)
+			}
+		})
+	}
+}

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -1,0 +1,185 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+)
+
+type parser struct {
+	toks []token
+	i    int
+}
+
+func (p *parser) peek() token {
+	return p.toks[p.i]
+}
+
+func (p *parser) peekN(n int) token {
+	if p.i+n >= len(p.toks) {
+		return p.toks[len(p.toks)-1]
+	}
+	return p.toks[p.i+n]
+}
+
+func (p *parser) advance() token {
+	t := p.toks[p.i]
+	if t.kind != tokEOF {
+		p.i++
+	}
+	return t
+}
+
+func (p *parser) parseQuery() (Node, error) {
+	if p.peek().kind == tokEOF {
+		return nil, nil
+	}
+	n, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	if p.peek().kind != tokEOF {
+		t := p.peek()
+		return nil, &ParseError{Pos: t.pos, Msg: fmt.Sprintf("unexpected %s", tokDesc(t))}
+	}
+	return n, nil
+}
+
+func (p *parser) parseOr() (Node, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.peek().kind == tokOr {
+		p.advance()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &OrNode{L: left, R: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseAnd() (Node, error) {
+	left, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		t := p.peek()
+		if t.kind == tokAnd {
+			p.advance()
+			right, err := p.parseUnary()
+			if err != nil {
+				return nil, err
+			}
+			left = &AndNode{L: left, R: right}
+			continue
+		}
+		if !startsUnary(t.kind) {
+			break
+		}
+		right, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		left = &AndNode{L: left, R: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseUnary() (Node, error) {
+	if p.peek().kind == tokNot {
+		p.advance()
+		inner, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return &NotNode{X: inner}, nil
+	}
+	return p.parsePrimary()
+}
+
+func (p *parser) parsePrimary() (Node, error) {
+	t := p.peek()
+	if t.kind == tokLParen {
+		p.advance()
+		if p.peek().kind == tokRParen {
+			return nil, &ParseError{Pos: p.peek().pos, Msg: "empty parentheses"}
+		}
+		inner, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		if p.peek().kind != tokRParen {
+			return nil, &ParseError{Pos: p.peek().pos, Msg: "expected ')'"}
+		}
+		p.advance()
+		return inner, nil
+	}
+	return p.parseTerm()
+}
+
+func (p *parser) parseTerm() (Node, error) {
+	t := p.peek()
+	if t.kind == tokWord && p.peekN(1).kind == tokColon {
+		field := strings.ToLower(t.value)
+		if !isValidField(field) {
+			return nil, &ParseError{
+				Pos: t.pos,
+				Msg: fmt.Sprintf("unknown field %q (valid: %s)", t.value, strings.Join(validFields, ", ")),
+			}
+		}
+		p.advance() // word
+		p.advance() // colon
+		v := p.peek()
+		switch v.kind {
+		case tokWord, tokQuoted, tokOr, tokAnd, tokNot:
+			p.advance()
+			return &TermNode{Field: field, Needle: strings.ToLower(v.value)}, nil
+		default:
+			return nil, &ParseError{Pos: v.pos, Msg: "expected value after ':'"}
+		}
+	}
+	switch t.kind {
+	case tokWord, tokQuoted:
+		p.advance()
+		return &TermNode{Needle: strings.ToLower(t.value)}, nil
+	case tokEOF:
+		return nil, &ParseError{Pos: t.pos, Msg: "unexpected end of input"}
+	default:
+		return nil, &ParseError{Pos: t.pos, Msg: fmt.Sprintf("unexpected %s", tokDesc(t))}
+	}
+}
+
+func startsUnary(k tokenKind) bool {
+	switch k {
+	case tokWord, tokQuoted, tokLParen, tokNot:
+		return true
+	}
+	return false
+}
+
+func tokDesc(t token) string {
+	switch t.kind {
+	case tokEOF:
+		return "end of input"
+	case tokLParen:
+		return "'('"
+	case tokRParen:
+		return "')'"
+	case tokColon:
+		return "':'"
+	case tokAnd:
+		return "AND"
+	case tokOr:
+		return "OR"
+	case tokNot:
+		return "NOT"
+	case tokWord:
+		return fmt.Sprintf("%q", t.value)
+	case tokQuoted:
+		return fmt.Sprintf("quoted %q", t.value)
+	}
+	return "token"
+}

--- a/internal/query/parser_test.go
+++ b/internal/query/parser_test.go
@@ -1,0 +1,149 @@
+package query
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  Node
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   ", nil},
+		{"single unfielded", "panic", &TermNode{Needle: "panic"}},
+		{"unfielded lowercased", "Panic", &TermNode{Needle: "panic"}},
+		{"single fielded", "title:foo", &TermNode{Field: "title", Needle: "foo"}},
+		{"fielded quoted", `title:"fix panic"`, &TermNode{Field: "title", Needle: "fix panic"}},
+		{"reserved word in value position",
+			"title:OR", &TermNode{Field: "title", Needle: "or"}},
+		{"implicit AND", "a b",
+			&AndNode{L: &TermNode{Needle: "a"}, R: &TermNode{Needle: "b"}}},
+		{"explicit AND", "a AND b",
+			&AndNode{L: &TermNode{Needle: "a"}, R: &TermNode{Needle: "b"}}},
+		{"three-way AND left-associates",
+			"a b c",
+			&AndNode{
+				L: &AndNode{L: &TermNode{Needle: "a"}, R: &TermNode{Needle: "b"}},
+				R: &TermNode{Needle: "c"},
+			}},
+		{"OR", "a OR b",
+			&OrNode{L: &TermNode{Needle: "a"}, R: &TermNode{Needle: "b"}}},
+		{"NOT", "NOT a", &NotNode{X: &TermNode{Needle: "a"}}},
+		{"leading dash is NOT", "-a", &NotNode{X: &TermNode{Needle: "a"}}},
+		{"NOT binds tighter than AND",
+			"NOT a b",
+			&AndNode{L: &NotNode{X: &TermNode{Needle: "a"}}, R: &TermNode{Needle: "b"}}},
+		{"AND tighter than OR",
+			"a b OR c",
+			&OrNode{
+				L: &AndNode{L: &TermNode{Needle: "a"}, R: &TermNode{Needle: "b"}},
+				R: &TermNode{Needle: "c"},
+			}},
+		{"parens override precedence",
+			"a (b OR c)",
+			&AndNode{
+				L: &TermNode{Needle: "a"},
+				R: &OrNode{L: &TermNode{Needle: "b"}, R: &TermNode{Needle: "c"}},
+			}},
+		{"dash before fielded",
+			"-tag:bug",
+			&NotNode{X: &TermNode{Field: "tag", Needle: "bug"}}},
+		{"ref fielded",
+			"ref:github.com",
+			&TermNode{Field: "ref", Needle: "github.com"}},
+		{"complex: issue-style",
+			"(ref:github.com OR ref:notion.so) tag:bug",
+			&AndNode{
+				L: &OrNode{
+					L: &TermNode{Field: "ref", Needle: "github.com"},
+					R: &TermNode{Field: "ref", Needle: "notion.so"},
+				},
+				R: &TermNode{Field: "tag", Needle: "bug"},
+			}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			q, err := Parse(c.input)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", c.input, err)
+			}
+			if !reflect.DeepEqual(q.root, c.want) {
+				t.Errorf("Parse(%q).root =\n  %#v\nwant\n  %#v", c.input, q.root, c.want)
+			}
+		})
+	}
+}
+
+func TestParseError(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"unknown field", "unknownfield:foo"},
+		{"trailing OR", "foo OR"},
+		{"leading OR", "OR foo"},
+		{"trailing AND", "a AND"},
+		{"leading AND", "AND a"},
+		{"empty parens", "()"},
+		{"unmatched LParen", "(a"},
+		{"unmatched RParen", "a)"},
+		{"missing value after colon", "title:"},
+		{"lone colon", ":"},
+		{"lone NOT", "NOT"},
+		{"lone dash", "-"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Parse(c.input)
+			if err == nil {
+				t.Fatalf("Parse(%q) expected error, got nil", c.input)
+			}
+			var pe *ParseError
+			if !errors.As(err, &pe) {
+				t.Fatalf("Parse(%q): expected *ParseError, got %T: %v", c.input, err, err)
+			}
+			if pe.Pos < 0 {
+				t.Errorf("Parse(%q): ParseError.Pos = %d, want >= 0", c.input, pe.Pos)
+			}
+		})
+	}
+}
+
+func TestParseErrorUnknownFieldMessage(t *testing.T) {
+	_, err := Parse("tilte:foo")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var pe *ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+	if !containsAll(pe.Msg, "unknown field", "tilte") {
+		t.Errorf("ParseError.Msg = %q; want to mention unknown field and \"tilte\"", pe.Msg)
+	}
+	if pe.Pos != 0 {
+		t.Errorf("ParseError.Pos = %d, want 0 (field position)", pe.Pos)
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -1,0 +1,86 @@
+// Package query implements a minimal query DSL for filtering items.
+//
+// Grammar:
+//
+//	query   := orExpr
+//	orExpr  := andExpr ( OR andExpr )*
+//	andExpr := unary ( unary )+        // implicit AND by juxtaposition
+//	unary   := ( NOT | '-' ) unary | primary
+//	primary := '(' query ')' | term
+//	term    := [WORD ':'] (WORD | QUOTED)
+//
+// Default match is case-insensitive substring. Field:value restricts the
+// match to a single field. Array-valued fields (tags, refs) match if any
+// element contains the needle.
+package query
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/takai/htd/internal/model"
+)
+
+// ParseError reports a problem at a specific byte offset in the input.
+type ParseError struct {
+	Pos int
+	Msg string
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("query: %s at pos %d", e.Msg, e.Pos)
+}
+
+// Query is a parsed, ready-to-evaluate query expression. The zero value
+// and queries parsed from the empty string match every item.
+type Query struct {
+	root Node
+}
+
+// Parse parses a query expression. Empty input produces a match-all Query.
+func Parse(input string) (*Query, error) {
+	toks, err := lex(input)
+	if err != nil {
+		return nil, err
+	}
+	p := &parser{toks: toks}
+	root, err := p.parseQuery()
+	if err != nil {
+		return nil, err
+	}
+	return &Query{root: root}, nil
+}
+
+// Match reports whether the item (plus its Markdown body) satisfies the
+// query. A match-all query returns true for every input.
+func (q *Query) Match(item *model.Item, body string) bool {
+	if q == nil || q.root == nil {
+		return true
+	}
+	ctx := &evalCtx{item: item, body: body}
+	return q.root.eval(ctx)
+}
+
+// ValidFields returns the whitelist of field names that can be used on the
+// left side of a colon (e.g., `title:foo`). Returned slice is a copy.
+func ValidFields() []string {
+	out := make([]string, len(validFields))
+	copy(out, validFields)
+	return out
+}
+
+var validFields = []string{
+	"id",
+	"title",
+	"body",
+	"kind",
+	"status",
+	"project",
+	"source",
+	"tag",
+	"ref",
+}
+
+func isValidField(name string) bool {
+	return slices.Contains(validFields, name)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,6 +21,15 @@ type Filter struct {
 	ProjectID string
 }
 
+// ItemWithBody bundles an item with its Markdown body as read from disk.
+// Callers that need body-level predicates (e.g. the --query DSL) should
+// use ListWithBody so the body is returned alongside the item in a single
+// read per file.
+type ItemWithBody struct {
+	Item *model.Item
+	Body string
+}
+
 func Read(path string) (*model.Item, string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -49,6 +58,24 @@ func Move(src, dst string, item *model.Item, body string) error {
 }
 
 func List(cfg *config.Config, filter Filter) ([]*model.Item, error) {
+	results, err := listScan(cfg, filter)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]*model.Item, len(results))
+	for i, r := range results {
+		items[i] = r.Item
+	}
+	return items, nil
+}
+
+// ListWithBody is like List but returns each item alongside its Markdown
+// body, read in the same pass. Results are sorted by CreatedAt ascending.
+func ListWithBody(cfg *config.Config, filter Filter) ([]ItemWithBody, error) {
+	return listScan(cfg, filter)
+}
+
+func listScan(cfg *config.Config, filter Filter) ([]ItemWithBody, error) {
 	var dirs []string
 
 	if filter.Kind != nil {
@@ -65,7 +92,7 @@ func List(cfg *config.Config, filter Filter) ([]*model.Item, error) {
 		dirs = append(dirs, cfg.ArchiveItemsDir())
 	}
 
-	var items []*model.Item
+	var results []ItemWithBody
 	seen := make(map[string]bool)
 
 	for _, dir := range dirs {
@@ -86,7 +113,7 @@ func List(cfg *config.Config, filter Filter) ([]*model.Item, error) {
 			}
 			seen[path] = true
 
-			item, _, err := Read(path)
+			item, body, err := Read(path)
 			if err != nil {
 				return nil, err
 			}
@@ -94,14 +121,14 @@ func List(cfg *config.Config, filter Filter) ([]*model.Item, error) {
 			if !matchFilter(item, filter) {
 				continue
 			}
-			items = append(items, item)
+			results = append(results, ItemWithBody{Item: item, Body: body})
 		}
 	}
 
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].CreatedAt.Before(items[j].CreatedAt)
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Item.CreatedAt.Before(results[j].Item.CreatedAt)
 	})
-	return items, nil
+	return results, nil
 }
 
 func matchFilter(item *model.Item, f Filter) bool {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -302,6 +302,42 @@ func TestListByProject(t *testing.T) {
 	}
 }
 
+// ---------- ListWithBody ----------
+
+func TestListWithBody(t *testing.T) {
+	cfg := newTestCfg(t)
+	if err := store.EnsureDirs(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	it1 := makeItem("20260417-a", model.KindInbox, model.StatusActive)
+	it2 := makeItem("20260417-b", model.KindInbox, model.StatusActive)
+	if err := store.Write(store.PathForItem(cfg, it1), it1, "first body"); err != nil {
+		t.Fatalf("Write a: %v", err)
+	}
+	if err := store.Write(store.PathForItem(cfg, it2), it2, "second body"); err != nil {
+		t.Fatalf("Write b: %v", err)
+	}
+
+	got, err := store.ListWithBody(cfg, store.Filter{})
+	if err != nil {
+		t.Fatalf("ListWithBody: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListWithBody: got %d items, want 2", len(got))
+	}
+	bodies := map[string]string{}
+	for _, r := range got {
+		bodies[r.Item.ID] = r.Body
+	}
+	if bodies["20260417-a"] != "first body" {
+		t.Errorf("body for a: got %q, want %q", bodies["20260417-a"], "first body")
+	}
+	if bodies["20260417-b"] != "second body" {
+		t.Errorf("body for b: got %q, want %q", bodies["20260417-b"], "second body")
+	}
+}
+
 // ---------- helpers ----------
 
 func makeItem(id string, kind model.Kind, status model.Status) *model.Item {

--- a/plugins/htd/agents/clarify.md
+++ b/plugins/htd/agents/clarify.md
@@ -40,7 +40,7 @@ You run the Clarify phase of the htd workflow. Your job is to turn every inbox i
 
 4. **Offer optional refinements** (never push):
    - Update the title if unclear: `htd clarify update <id> --title "<new>"`.
-   - Link to a project: `htd organize link <id> --project <project-id>`. Only suggest this if you can see an obvious candidate in `htd item list --kind project --json`.
+   - Link to a project: `htd organize link <id> --project <project-id>`. Only suggest this if a candidate shows up in a keyword-narrowed search: `htd item list --kind project --query '<keyword from the item>' --json`.
    - Schedule due/defer/review: `htd organize schedule <id> ...`. Only if the user mentions timing.
    - Add tags: `htd item update <id> tags='[a,b]'`.
 

--- a/plugins/htd/commands/organize.md
+++ b/plugins/htd/commands/organize.md
@@ -25,7 +25,7 @@ If `$ARGUMENTS` is empty, ask which item they want to organize (offer to show `h
 3. Propose organization changes based on the title and body. Ask the user about each dimension that could be set, but skip ones that are already reasonable. For each proposal, show the exact `htd` command and wait for confirmation before running.
 
    - **Kind** — if it's still `inbox` or the wrong kind, suggest one of next_action / project / waiting_for / someday / tickler and run `htd organize move <kind> <id>`. Cannot target `inbox`. If the item clearly needs to become a project with obvious first sub-actions, prefer `htd organize promote <id> --child "<title 1>" [--child "<title 2>"]...` to promote and seed children in one shot.
-   - **Project link** — if the item looks related to an existing project, suggest it. To find candidates: `htd item list --kind project --status active --json`. Run `htd organize link <id> --project <project-id>` to link, or `--project ""` to clear.
+   - **Project link** — if the item looks related to an existing project, suggest it. To narrow candidates, pick one or two keywords from the item's title/body and search with `--query`: `htd item list --kind project --query '<keyword>' --json` (or combine terms: `--query 'cli OR docs'`). Fall back to `htd item list --kind project --status active --json` only if nothing matches. Run `htd organize link <id> --project <project-id>` to link, or `--project ""` to clear.
    - **Dates** — if the user mentions timing ("next week", "by Friday", "defer until the 15th"), convert to `YYYY-MM-DD` and run `htd organize schedule <id> [--due …] [--defer …] [--review …]`. Pass `""` to clear a date.
    - **Tags** — if the user wants to tag: `htd item update <id> tags='[a,b]'`.
 

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -80,7 +80,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 
 **Item (low-level CRUD)** — use for scripting; workflow commands are preferred.
 - `htd item get ID`
-- `htd item list [--kind KIND] [--status STATUS] [--tag TAG] [--project PID]`
+- `htd item list [--kind KIND] [--status STATUS] [--tag TAG] [--project PID] [--query EXPR]` — `--query` accepts a small DSL (substring by default, `field:value` for targeted match, `AND`/`OR`/`NOT`/parens). Useful for narrowing project candidates, e.g. `htd item list --kind project --query 'cli OR docs' --json`.
 - `htd item update ID FIELD=VALUE...` — `id` and `created_at` are protected.
 - `htd item archive ID`
 - `htd item restore ID` — undo an accidental `engage done`/`cancel`/`discard`/`archive`; brings a terminal item back to `active` and moves it to `items/<kind>/`.


### PR DESCRIPTION
## Summary

- Introduce a new `internal/query` package implementing a minimal query DSL (lexer, parser, AST, evaluator) with case-insensitive substring matching, implicit/explicit AND, OR, NOT/-, parens, quoted values, and a field whitelist (`id`, `title`, `body`, `kind`, `status`, `project`, `source`, `tag`, `ref`).
- Wire `--query EXPR` into `htd item list`, AND-composing with the existing `--kind/--status/--tag/--project` flags. Add `store.ListWithBody` so the evaluator can match against Markdown body content in a single file read.
- Document the DSL in `docs/cli.md` §7.2.1 with grammar, field list, composition rules, and examples.

Closes #23.

## Test plan

- [x] `mise run test` — unit tests for lexer, parser, evaluator, `store.ListWithBody`; integration tests for `item list --query` covering unfielded, fielded, body match, tag/ref array-any, boolean + parens, composition with flags, empty-query match-all, invalid-expression error path.
- [x] `mise run lint` — clean.
- [x] Manual smoke test against a fresh `htd init` tree: `panic`, `title:"fix panic"`, `ref:github.com`, `(tag:bug OR tag:docs) NOT title:refactor`, empty query, invalid expression.

## Notes

- `refs:`/`tags:` plural are intentionally rejected in favor of singular `ref:`/`tag:` to match the `--ref`/`--tag` CLI flags.
- URL values containing `:` must be quoted (`ref:"https://…"`); hostname-only matches work unquoted.
- Date fields and operators beyond substring (`==`, `~=`, `in`, regex) are explicit non-goals for v1.