### PR TITLE
feat: --verbose flag for mutation confirmations

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,7 @@ Command groups map to the five workflow phases plus a low-level `item` group:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--json` | flag | `false` | Output in JSON format instead of human-readable text |
+| `--verbose` / `-v` | flag | `false` | Print per-mutation confirmations on mutating commands (see §1.6) |
 | `--path` | string | `$HTD_PATH` or `.` | Specify the htd root directory (overrides `$HTD_PATH`) |
 
 Global options may appear before or after the command group.
@@ -55,6 +56,22 @@ Resolution order for the root directory: `--path` (if given) → `$HTD_PATH` (if
 - **Default (human-readable)**: Tab-separated columns for lists, YAML-like key-value for detail views.
 - **`--json`**: A single JSON object (for `show`/`get`) or a JSON array (for `list`) written to stdout.
 - **Errors**: Written to stderr.
+
+### 1.6 Verbose Mode on Mutating Commands
+
+Mutating commands (see below) exit silently on success by default, which keeps pipelines script-friendly. Pass `--verbose` / `-v` to surface what happened:
+
+- **Text mode**: one `updated <id>: field=value [field=value ...]` line per item. Only the fields actually changed are shown. Date inputs are echoed back in RFC 3339 form (e.g., `--defer 2026-04-27` is reported as `defer_until=2026-04-27T00:00:00+09:00`).
+- **`--json --verbose`**: a single JSON array containing the full, post-mutation item object(s), matching the shape produced by read commands like `item get` / `item list`.
+
+Affected commands:
+
+- `htd clarify update` / `clarify discard`
+- `htd organize move` / `organize link` / `organize schedule`
+- `htd engage done` / `engage cancel`
+- `htd item update` / `item archive` / `item restore`
+
+Commands that already print on success (`capture add`, `organize promote`, `reflect tickler --pull`, `init`) ignore `--verbose`; their output is unchanged.
 
 ---
 

--- a/internal/command/clarify.go
+++ b/internal/command/clarify.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/takai/htd/internal/model"
+	"github.com/takai/htd/internal/output"
 	"github.com/takai/htd/internal/store"
 )
 
@@ -92,11 +93,14 @@ func newClarifyUpdateCommand(c *container) *cobra.Command {
 			if item.Kind != model.KindInbox {
 				return &store.NotFoundError{ID: itemID}
 			}
+			var changes []output.Change
 			if cmd.Flags().Changed("title") {
 				item.Title = title
+				changes = append(changes, output.Change{Key: "title", Value: title})
 			}
 			if cmd.Flags().Changed("body") {
 				existingBody = body
+				changes = append(changes, output.Change{Key: "body", Value: body})
 			}
 			if cmd.Flags().Changed("ref") {
 				if len(refs) == 0 {
@@ -104,9 +108,14 @@ func newClarifyUpdateCommand(c *container) *cobra.Command {
 				} else {
 					item.Refs = refs
 				}
+				changes = append(changes, output.Change{Key: "refs", Value: output.FormatList(item.Refs)})
 			}
 			item.UpdatedAt = time.Now()
-			return store.Write(path, item, existingBody)
+			if err := store.Write(path, item, existingBody); err != nil {
+				return err
+			}
+			c.printer.PrintUpdates([]output.Update{{Item: item, Changes: changes}})
+			return nil
 		},
 	}
 
@@ -137,7 +146,14 @@ func newClarifyDiscardCommand(c *container) *cobra.Command {
 			item.Status = model.StatusDiscarded
 			item.UpdatedAt = time.Now()
 			newPath := store.PathForItem(c.cfg, item)
-			return store.Move(path, newPath, item, body)
+			if err := store.Move(path, newPath, item, body); err != nil {
+				return err
+			}
+			c.printer.PrintUpdates([]output.Update{{
+				Item:    item,
+				Changes: []output.Change{{Key: "status", Value: string(model.StatusDiscarded)}},
+			}})
+			return nil
 		},
 	}
 }

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -2153,6 +2153,199 @@ func TestHTDPathFlagOverridesEnvVar(t *testing.T) {
 	}
 }
 
+// ---------- verbose ----------
+
+func TestMutationsSilentByDefault(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-mute", model.KindNextAction, model.StatusActive), "")
+
+	out, errOut, err := runCmd(t, dir, "engage", "done", "20260421-mute")
+	if err != nil {
+		t.Fatalf("engage done: %v", err)
+	}
+	if out != "" {
+		t.Errorf("default stdout should be silent, got %q", out)
+	}
+	if errOut != "" {
+		t.Errorf("default stderr should be silent, got %q", errOut)
+	}
+}
+
+func TestEngageDoneVerboseText(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-vd1", model.KindNextAction, model.StatusActive), "")
+	writeItem(t, dir, nowItem("20260421-vd2", model.KindNextAction, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "--verbose", "engage", "done", "20260421-vd1", "20260421-vd2")
+	if err != nil {
+		t.Fatalf("engage done --verbose: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d: %q", len(lines), out)
+	}
+	want := []string{
+		"updated 20260421-vd1: status=done",
+		"updated 20260421-vd2: status=done",
+	}
+	for i, w := range want {
+		if lines[i] != w {
+			t.Errorf("line %d: want %q, got %q", i, w, lines[i])
+		}
+	}
+}
+
+func TestEngageDoneVerboseJSON(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-vj1", model.KindNextAction, model.StatusActive), "")
+	writeItem(t, dir, nowItem("20260421-vj2", model.KindNextAction, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "--verbose", "--json", "engage", "done", "20260421-vj1", "20260421-vj2")
+	if err != nil {
+		t.Fatalf("engage done --verbose --json: %v", err)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(out), &arr); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("want 2 items, got %d", len(arr))
+	}
+	for i, id := range []string{"20260421-vj1", "20260421-vj2"} {
+		if arr[i]["id"] != id {
+			t.Errorf("item %d id: want %q, got %v", i, id, arr[i]["id"])
+		}
+		if arr[i]["status"] != "done" {
+			t.Errorf("item %d status: want done, got %v", i, arr[i]["status"])
+		}
+	}
+}
+
+func TestOrganizeScheduleVerboseShowsRFC3339(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-vs", model.KindNextAction, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "-v", "organize", "schedule", "20260421-vs", "--defer", "2026-04-27")
+	if err != nil {
+		t.Fatalf("organize schedule -v: %v", err)
+	}
+	line := strings.TrimRight(out, "\n")
+	if !strings.HasPrefix(line, "updated 20260421-vs: defer_until=2026-04-27T00:00:00") {
+		t.Errorf("expected defer_until expanded to RFC3339 in verbose output, got %q", line)
+	}
+}
+
+func TestOrganizeMoveVerbose(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-vm", model.KindInbox, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "-v", "organize", "move", "next_action", "20260421-vm")
+	if err != nil {
+		t.Fatalf("organize move -v: %v", err)
+	}
+	want := "updated 20260421-vm: kind=next_action\n"
+	if out != want {
+		t.Errorf("want %q, got %q", want, out)
+	}
+}
+
+func TestOrganizeLinkVerbose(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-vp", model.KindProject, model.StatusActive), "")
+	writeItem(t, dir, nowItem("20260421-vt", model.KindNextAction, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "-v", "organize", "link", "20260421-vt", "--project", "20260421-vp")
+	if err != nil {
+		t.Fatalf("organize link -v: %v", err)
+	}
+	want := "updated 20260421-vt: project=20260421-vp\n"
+	if out != want {
+		t.Errorf("want %q, got %q", want, out)
+	}
+}
+
+func TestClarifyDiscardVerbose(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-vcd", model.KindInbox, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "-v", "clarify", "discard", "20260421-vcd")
+	if err != nil {
+		t.Fatalf("clarify discard -v: %v", err)
+	}
+	want := "updated 20260421-vcd: status=discarded\n"
+	if out != want {
+		t.Errorf("want %q, got %q", want, out)
+	}
+}
+
+func TestClarifyUpdateVerbose(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-vcu", model.KindInbox, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "-v", "clarify", "update", "20260421-vcu",
+		"--title", "Renamed", "--ref", "https://example.com/1")
+	if err != nil {
+		t.Fatalf("clarify update -v: %v", err)
+	}
+	line := strings.TrimRight(out, "\n")
+	if !strings.Contains(line, "title=Renamed") {
+		t.Errorf("missing title change: %q", line)
+	}
+	if !strings.Contains(line, "refs=[https://example.com/1]") {
+		t.Errorf("missing refs change: %q", line)
+	}
+}
+
+func TestItemUpdateVerboseMultiField(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-viu", model.KindNextAction, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "-v", "item", "update", "20260421-viu",
+		"title=Renamed", "defer_until=2026-04-27", "tags=[cli,docs]")
+	if err != nil {
+		t.Fatalf("item update -v: %v", err)
+	}
+	line := strings.TrimRight(out, "\n")
+	if !strings.Contains(line, "title=Renamed") {
+		t.Errorf("missing title=Renamed: %q", line)
+	}
+	if !strings.Contains(line, "defer_until=2026-04-27T00:00:00") {
+		t.Errorf("defer_until should expand to RFC3339: %q", line)
+	}
+	if !strings.Contains(line, "tags=[cli,docs]") {
+		t.Errorf("tags should be normalized: %q", line)
+	}
+}
+
+func TestItemArchiveVerbose(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260421-via", model.KindNextAction, model.StatusActive), "")
+
+	out, _, err := runCmd(t, dir, "-v", "item", "archive", "20260421-via")
+	if err != nil {
+		t.Fatalf("item archive -v: %v", err)
+	}
+	want := "updated 20260421-via: status=archived\n"
+	if out != want {
+		t.Errorf("want %q, got %q", want, out)
+	}
+}
+
+func TestItemRestoreVerbose(t *testing.T) {
+	dir := setupDir(t)
+	it := nowItem("20260421-vir", model.KindNextAction, model.StatusDone)
+	writeItem(t, dir, it, "")
+
+	out, _, err := runCmd(t, dir, "-v", "item", "restore", "20260421-vir")
+	if err != nil {
+		t.Fatalf("item restore -v: %v", err)
+	}
+	want := "updated 20260421-vir: status=active\n"
+	if out != want {
+		t.Errorf("want %q, got %q", want, out)
+	}
+}
+
 // ---------- helper ----------
 
 func firstN(s string, n int) string {

--- a/internal/command/engage.go
+++ b/internal/command/engage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/takai/htd/internal/model"
+	"github.com/takai/htd/internal/output"
 	"github.com/takai/htd/internal/store"
 )
 
@@ -32,12 +33,7 @@ func newEngageDoneCommand(c *container) *cobra.Command {
 		Short: "Mark one or more items as completed",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			for _, id := range args {
-				if err := terminateItem(c, id, model.StatusDone); err != nil {
-					return err
-				}
-			}
-			return nil
+			return runTerminate(c, args, model.StatusDone)
 		},
 	}
 }
@@ -48,14 +44,25 @@ func newEngageCancelCommand(c *container) *cobra.Command {
 		Short: "Cancel one or more active items",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			for _, id := range args {
-				if err := terminateItem(c, id, model.StatusCanceled); err != nil {
-					return err
-				}
-			}
-			return nil
+			return runTerminate(c, args, model.StatusCanceled)
 		},
 	}
+}
+
+func runTerminate(c *container, ids []string, status model.Status) error {
+	var updates []output.Update
+	for _, id := range ids {
+		item, err := terminateItem(c, id, status)
+		if err != nil {
+			return err
+		}
+		updates = append(updates, output.Update{
+			Item:    item,
+			Changes: []output.Change{{Key: "status", Value: string(status)}},
+		})
+	}
+	c.printer.PrintUpdates(updates)
+	return nil
 }
 
 func newEngageNextActionCommand(c *container) *cobra.Command {
@@ -168,20 +175,23 @@ func matchAllTags(it *model.Item, tags []string) bool {
 	return true
 }
 
-func terminateItem(c *container, itemID string, status model.Status) error {
+func terminateItem(c *container, itemID string, status model.Status) (*model.Item, error) {
 	path, err := store.FindItem(c.cfg, itemID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	item, body, err := store.Read(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !model.IsActive(item.Status) {
-		return fmt.Errorf("item %q is not active (status: %s)", itemID, item.Status)
+		return nil, fmt.Errorf("item %q is not active (status: %s)", itemID, item.Status)
 	}
 	item.Status = status
 	item.UpdatedAt = time.Now()
 	newPath := store.PathForItem(c.cfg, item)
-	return store.Move(path, newPath, item, body)
+	if err := store.Move(path, newPath, item, body); err != nil {
+		return nil, err
+	}
+	return item, nil
 }

--- a/internal/command/item.go
+++ b/internal/command/item.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/takai/htd/internal/model"
+	"github.com/takai/htd/internal/output"
 	"github.com/takai/htd/internal/query"
 	"github.com/takai/htd/internal/store"
 )
@@ -135,6 +136,7 @@ func newItemUpdateCommand(c *container) *cobra.Command {
 
 			oldPath := store.PathForItem(c.cfg, item)
 
+			var changes []output.Change
 			for _, pair := range pairs {
 				k, v, ok := strings.Cut(pair, "=")
 				if !ok {
@@ -143,15 +145,42 @@ func newItemUpdateCommand(c *container) *cobra.Command {
 				if err := applyField(item, &body, k, v); err != nil {
 					return err
 				}
+				changes = append(changes, output.Change{Key: k, Value: normalizedFieldValue(item, k, v)})
 			}
 			item.UpdatedAt = time.Now()
 
 			newPath := store.PathForItem(c.cfg, item)
 			if oldPath != newPath {
-				return store.Move(oldPath, newPath, item, body)
+				if err := store.Move(oldPath, newPath, item, body); err != nil {
+					return err
+				}
+			} else if err := store.Write(path, item, body); err != nil {
+				return err
 			}
-			return store.Write(path, item, body)
+			c.printer.PrintUpdates([]output.Update{{Item: item, Changes: changes}})
+			return nil
 		},
+	}
+}
+
+// normalizedFieldValue returns the on-disk representation of the field after
+// applyField ran, so verbose output shows the effective value (e.g., a
+// date-only input expanded to RFC3339, or `[a,b]` for tag lists). Falls
+// back to the raw input for free-form fields.
+func normalizedFieldValue(item *model.Item, key, raw string) string {
+	switch key {
+	case "due_at":
+		return output.FormatTimePtr(item.DueAt)
+	case "defer_until":
+		return output.FormatTimePtr(item.DeferUntil)
+	case "review_at":
+		return output.FormatTimePtr(item.ReviewAt)
+	case "tags":
+		return output.FormatList(item.Tags)
+	case "refs":
+		return output.FormatList(item.Refs)
+	default:
+		return raw
 	}
 }
 
@@ -257,7 +286,14 @@ func newItemArchiveCommand(c *container) *cobra.Command {
 			item.Status = model.StatusArchived
 			item.UpdatedAt = time.Now()
 			newPath := store.PathForItem(c.cfg, item)
-			return store.Move(path, newPath, item, body)
+			if err := store.Move(path, newPath, item, body); err != nil {
+				return err
+			}
+			c.printer.PrintUpdates([]output.Update{{
+				Item:    item,
+				Changes: []output.Change{{Key: "status", Value: string(model.StatusArchived)}},
+			}})
+			return nil
 		},
 	}
 }
@@ -283,7 +319,14 @@ func newItemRestoreCommand(c *container) *cobra.Command {
 			item.Status = model.StatusActive
 			item.UpdatedAt = time.Now()
 			newPath := store.PathForItem(c.cfg, item)
-			return store.Move(path, newPath, item, body)
+			if err := store.Move(path, newPath, item, body); err != nil {
+				return err
+			}
+			c.printer.PrintUpdates([]output.Update{{
+				Item:    item,
+				Changes: []output.Change{{Key: "status", Value: string(model.StatusActive)}},
+			}})
+			return nil
 		},
 	}
 }

--- a/internal/command/organize.go
+++ b/internal/command/organize.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/takai/htd/internal/model"
+	"github.com/takai/htd/internal/output"
 	"github.com/takai/htd/internal/store"
 )
 
@@ -41,35 +42,48 @@ func newOrganizeMoveCommand(c *container) *cobra.Command {
 				return fmt.Errorf("invalid kind %q", newKind)
 			}
 
+			var updates []output.Update
 			for _, itemID := range ids {
-				if err := moveItem(c, itemID, newKind); err != nil {
+				item, err := moveItem(c, itemID, newKind)
+				if err != nil {
 					return err
 				}
+				updates = append(updates, output.Update{
+					Item:    item,
+					Changes: []output.Change{{Key: "kind", Value: string(newKind)}},
+				})
 			}
+			c.printer.PrintUpdates(updates)
 			return nil
 		},
 	}
 }
 
-func moveItem(c *container, itemID string, newKind model.Kind) error {
+func moveItem(c *container, itemID string, newKind model.Kind) (*model.Item, error) {
 	path, err := store.FindItem(c.cfg, itemID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	item, body, err := store.Read(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !model.IsActive(item.Status) {
-		return fmt.Errorf("cannot move item with status %q", item.Status)
+		return nil, fmt.Errorf("cannot move item with status %q", item.Status)
 	}
 	item.Kind = newKind
 	item.UpdatedAt = time.Now()
 	newPath := store.PathForItem(c.cfg, item)
 	if path == newPath {
-		return store.Write(path, item, body)
+		if err := store.Write(path, item, body); err != nil {
+			return nil, err
+		}
+		return item, nil
 	}
-	return store.Move(path, newPath, item, body)
+	if err := store.Move(path, newPath, item, body); err != nil {
+		return nil, err
+	}
+	return item, nil
 }
 
 func newOrganizeLinkCommand(c *container) *cobra.Command {
@@ -106,7 +120,14 @@ func newOrganizeLinkCommand(c *container) *cobra.Command {
 			}
 			item.Project = projectID
 			item.UpdatedAt = time.Now()
-			return store.Write(path, item, body)
+			if err := store.Write(path, item, body); err != nil {
+				return err
+			}
+			c.printer.PrintUpdates([]output.Update{{
+				Item:    item,
+				Changes: []output.Change{{Key: "project", Value: projectID}},
+			}})
+			return nil
 		},
 	}
 
@@ -141,12 +162,14 @@ func newOrganizeScheduleCommand(c *container) *cobra.Command {
 				return err
 			}
 
+			var changes []output.Change
 			if cmd.Flags().Changed("due") {
 				t, err := parseDate(due)
 				if err != nil {
 					return fmt.Errorf("--due: %w", err)
 				}
 				item.DueAt = t
+				changes = append(changes, output.Change{Key: "due_at", Value: output.FormatTimePtr(t)})
 			}
 			if cmd.Flags().Changed("defer") {
 				t, err := parseDate(defer_)
@@ -154,6 +177,7 @@ func newOrganizeScheduleCommand(c *container) *cobra.Command {
 					return fmt.Errorf("--defer: %w", err)
 				}
 				item.DeferUntil = t
+				changes = append(changes, output.Change{Key: "defer_until", Value: output.FormatTimePtr(t)})
 			}
 			if cmd.Flags().Changed("review") {
 				t, err := parseDate(review)
@@ -161,10 +185,15 @@ func newOrganizeScheduleCommand(c *container) *cobra.Command {
 					return fmt.Errorf("--review: %w", err)
 				}
 				item.ReviewAt = t
+				changes = append(changes, output.Change{Key: "review_at", Value: output.FormatTimePtr(t)})
 			}
 
 			item.UpdatedAt = time.Now()
-			return store.Write(path, item, body)
+			if err := store.Write(path, item, body); err != nil {
+				return err
+			}
+			c.printer.PrintUpdates([]output.Update{{Item: item, Changes: changes}})
+			return nil
 		},
 	}
 

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -20,6 +20,7 @@ type container struct {
 func NewRootCommand() *cobra.Command {
 	var (
 		jsonMode bool
+		verbose  bool
 		path     string
 		c        container
 	)
@@ -31,6 +32,7 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	root.PersistentFlags().BoolVar(&jsonMode, "json", false, "Output in JSON format")
+	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Print per-mutation confirmations on mutating commands")
 	root.PersistentFlags().StringVar(&path, "path", ".", "htd root directory (overrides $HTD_PATH)")
 
 	root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
@@ -40,7 +42,7 @@ func NewRootCommand() *cobra.Command {
 			}
 		}
 		c.cfg = config.New(path)
-		c.printer = output.New(cmd.OutOrStdout(), cmd.ErrOrStderr(), jsonMode)
+		c.printer = output.New(cmd.OutOrStdout(), cmd.ErrOrStderr(), jsonMode, verbose)
 		if isCompletionCommand(cmd) {
 			return nil
 		}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -17,13 +18,72 @@ const (
 )
 
 type Printer struct {
-	out  io.Writer
-	err  io.Writer
-	json bool
+	out     io.Writer
+	err     io.Writer
+	json    bool
+	verbose bool
 }
 
-func New(out, err io.Writer, jsonMode bool) *Printer {
-	return &Printer{out: out, err: err, json: jsonMode}
+func New(out, err io.Writer, jsonMode, verbose bool) *Printer {
+	return &Printer{out: out, err: err, json: jsonMode, verbose: verbose}
+}
+
+// Verbose reports whether the printer is in verbose mode. Commands can skip
+// the cost of building an update report when verbose output is disabled.
+func (p *Printer) Verbose() bool { return p.verbose }
+
+// Change is a single field=value pair in a verbose update report.
+type Change struct {
+	Key   string
+	Value string
+}
+
+// Update bundles an item and the fields changed on it, for PrintUpdates.
+type Update struct {
+	Item    *model.Item
+	Changes []Change
+}
+
+// PrintUpdates emits per-mutation confirmations when verbose mode is on; a
+// no-op otherwise so scripts that relied on silence keep working.
+//
+// Text: one `updated <id>: k=v k=v` line per update.
+// JSON: a single array of full item objects, matching read-command shape.
+func (p *Printer) PrintUpdates(updates []Update) {
+	if !p.verbose {
+		return
+	}
+	if p.json {
+		arr := make([]itemJSON, len(updates))
+		for i, u := range updates {
+			arr[i] = toItemJSON(u.Item, "")
+		}
+		data, _ := json.Marshal(arr)
+		fmt.Fprintln(p.out, string(data))
+		return
+	}
+	for _, u := range updates {
+		fmt.Fprint(p.out, "updated ", u.Item.ID, ":")
+		for _, c := range u.Changes {
+			fmt.Fprintf(p.out, " %s=%s", c.Key, c.Value)
+		}
+		fmt.Fprintln(p.out)
+	}
+}
+
+// FormatTimePtr renders a *time.Time as the caller should show it in verbose
+// change reports: empty string when nil (field cleared), RFC3339 otherwise.
+func FormatTimePtr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format("2006-01-02T15:04:05Z07:00")
+}
+
+// FormatList renders a string slice as `[a,b,c]` for verbose change reports.
+// An empty slice renders as `[]` so the caller can see the field was cleared.
+func FormatList(xs []string) string {
+	return "[" + strings.Join(xs, ",") + "]"
 }
 
 func (p *Printer) PrintID(id string) {

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -27,7 +27,7 @@ func makeItem(id string, kind model.Kind) *model.Item {
 
 func TestPrintItemText(t *testing.T) {
 	var out bytes.Buffer
-	p := output.New(&out, &bytes.Buffer{}, false)
+	p := output.New(&out, &bytes.Buffer{}, false, false)
 	item := makeItem("20260417-test", model.KindInbox)
 	p.PrintItem(item, "some body text")
 
@@ -42,7 +42,7 @@ func TestPrintItemText(t *testing.T) {
 
 func TestPrintItemJSON(t *testing.T) {
 	var out bytes.Buffer
-	p := output.New(&out, &bytes.Buffer{}, true)
+	p := output.New(&out, &bytes.Buffer{}, true, false)
 	item := makeItem("20260417-json", model.KindNextAction)
 	p.PrintItem(item, "body content")
 
@@ -60,7 +60,7 @@ func TestPrintItemJSON(t *testing.T) {
 
 func TestPrintItemsText(t *testing.T) {
 	var out bytes.Buffer
-	p := output.New(&out, &bytes.Buffer{}, false)
+	p := output.New(&out, &bytes.Buffer{}, false, false)
 	items := []*model.Item{
 		makeItem("20260417-a", model.KindInbox),
 		makeItem("20260417-b", model.KindProject),
@@ -75,7 +75,7 @@ func TestPrintItemsText(t *testing.T) {
 
 func TestPrintItemsTextTruncatesTitleByRunes(t *testing.T) {
 	var out bytes.Buffer
-	p := output.New(&out, &bytes.Buffer{}, false)
+	p := output.New(&out, &bytes.Buffer{}, false, false)
 	long := strings.Repeat("チ", 50)
 	item := makeItem("20260417-a", model.KindInbox)
 	item.Title = long
@@ -92,7 +92,7 @@ func TestPrintItemsTextTruncatesTitleByRunes(t *testing.T) {
 
 func TestPrintItemsTextAlignsLongIDs(t *testing.T) {
 	var out bytes.Buffer
-	p := output.New(&out, &bytes.Buffer{}, false)
+	p := output.New(&out, &bytes.Buffer{}, false, false)
 	longID := "20260417-" + strings.Repeat("x", 60)
 	items := []*model.Item{
 		makeItem(longID, model.KindInbox),
@@ -119,7 +119,7 @@ func TestPrintItemsTextAlignsLongIDs(t *testing.T) {
 
 func TestPrintItemsJSON(t *testing.T) {
 	var out bytes.Buffer
-	p := output.New(&out, &bytes.Buffer{}, true)
+	p := output.New(&out, &bytes.Buffer{}, true, false)
 	items := []*model.Item{
 		makeItem("20260417-x", model.KindInbox),
 	}
@@ -136,7 +136,7 @@ func TestPrintItemsJSON(t *testing.T) {
 
 func TestPrintError(t *testing.T) {
 	var errOut bytes.Buffer
-	p := output.New(&bytes.Buffer{}, &errOut, false)
+	p := output.New(&bytes.Buffer{}, &errOut, false, false)
 	p.PrintError("something went wrong")
 
 	if !strings.Contains(errOut.String(), "something went wrong") {
@@ -146,7 +146,7 @@ func TestPrintError(t *testing.T) {
 
 func TestPrintID(t *testing.T) {
 	var out bytes.Buffer
-	p := output.New(&out, &bytes.Buffer{}, false)
+	p := output.New(&out, &bytes.Buffer{}, false, false)
 	p.PrintID("20260417-new_item")
 
 	if strings.TrimSpace(out.String()) != "20260417-new_item" {
@@ -156,7 +156,7 @@ func TestPrintID(t *testing.T) {
 
 func TestPrintPathsText(t *testing.T) {
 	var out bytes.Buffer
-	p := output.New(&out, &bytes.Buffer{}, false)
+	p := output.New(&out, &bytes.Buffer{}, false, false)
 	p.PrintPaths([]string{"items/inbox", "items/project", "reference"})
 
 	want := "items/inbox\nitems/project\nreference\n"
@@ -167,7 +167,7 @@ func TestPrintPathsText(t *testing.T) {
 
 func TestPrintPathsJSON(t *testing.T) {
 	var out bytes.Buffer
-	p := output.New(&out, &bytes.Buffer{}, true)
+	p := output.New(&out, &bytes.Buffer{}, true, false)
 	p.PrintPaths([]string{"items/inbox", "reference"})
 
 	var arr []string
@@ -176,5 +176,96 @@ func TestPrintPathsJSON(t *testing.T) {
 	}
 	if len(arr) != 2 || arr[0] != "items/inbox" || arr[1] != "reference" {
 		t.Errorf("PrintPaths JSON: got %v", arr)
+	}
+}
+
+func TestPrintUpdatesSilentByDefault(t *testing.T) {
+	var out bytes.Buffer
+	p := output.New(&out, &bytes.Buffer{}, false, false)
+	item := makeItem("20260417-mute", model.KindInbox)
+	p.PrintUpdates([]output.Update{{
+		Item:    item,
+		Changes: []output.Change{{Key: "status", Value: "done"}},
+	}})
+	if out.Len() != 0 {
+		t.Errorf("PrintUpdates without --verbose should be silent, got %q", out.String())
+	}
+}
+
+func TestPrintUpdatesVerboseText(t *testing.T) {
+	var out bytes.Buffer
+	p := output.New(&out, &bytes.Buffer{}, false, true)
+	item := makeItem("20260417-v", model.KindInbox)
+	p.PrintUpdates([]output.Update{{
+		Item: item,
+		Changes: []output.Change{
+			{Key: "kind", Value: "next_action"},
+			{Key: "due_at", Value: "2026-05-01T00:00:00Z"},
+		},
+	}})
+	want := "updated 20260417-v: kind=next_action due_at=2026-05-01T00:00:00Z\n"
+	if got := out.String(); got != want {
+		t.Errorf("verbose text: want %q, got %q", want, got)
+	}
+}
+
+func TestPrintUpdatesVerboseTextBulk(t *testing.T) {
+	var out bytes.Buffer
+	p := output.New(&out, &bytes.Buffer{}, false, true)
+	a := makeItem("20260417-a", model.KindInbox)
+	b := makeItem("20260417-b", model.KindInbox)
+	p.PrintUpdates([]output.Update{
+		{Item: a, Changes: []output.Change{{Key: "status", Value: "done"}}},
+		{Item: b, Changes: []output.Change{{Key: "status", Value: "done"}}},
+	})
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d: %q", len(lines), out.String())
+	}
+	if !strings.HasPrefix(lines[0], "updated 20260417-a:") {
+		t.Errorf("line 0: %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "updated 20260417-b:") {
+		t.Errorf("line 1: %q", lines[1])
+	}
+}
+
+func TestPrintUpdatesVerboseJSON(t *testing.T) {
+	var out bytes.Buffer
+	p := output.New(&out, &bytes.Buffer{}, true, true)
+	a := makeItem("20260417-a", model.KindInbox)
+	b := makeItem("20260417-b", model.KindProject)
+	p.PrintUpdates([]output.Update{
+		{Item: a, Changes: []output.Change{{Key: "status", Value: "done"}}},
+		{Item: b, Changes: []output.Change{{Key: "status", Value: "done"}}},
+	})
+	var arr []map[string]any
+	if err := json.Unmarshal(out.Bytes(), &arr); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, out.String())
+	}
+	if len(arr) != 2 {
+		t.Fatalf("want 2 items in array, got %d", len(arr))
+	}
+	if arr[0]["id"] != "20260417-a" || arr[1]["id"] != "20260417-b" {
+		t.Errorf("JSON IDs: got %v", arr)
+	}
+}
+
+func TestFormatTimePtr(t *testing.T) {
+	if got := output.FormatTimePtr(nil); got != "" {
+		t.Errorf("nil: want %q, got %q", "", got)
+	}
+	ts := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	if got := output.FormatTimePtr(&ts); got != "2026-05-01T00:00:00Z" {
+		t.Errorf("ts: got %q", got)
+	}
+}
+
+func TestFormatList(t *testing.T) {
+	if got := output.FormatList(nil); got != "[]" {
+		t.Errorf("nil: want %q, got %q", "[]", got)
+	}
+	if got := output.FormatList([]string{"a", "b", "c"}); got != "[a,b,c]" {
+		t.Errorf("a,b,c: got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Add a persistent `--verbose` / `-v` flag. When set, mutating commands emit per-item confirmations; when unset, they stay silent on success (preserves existing script-friendly behavior).
- Text output: `updated <id>: field=value [field=value...]` — only changed fields, dates expanded to RFC 3339.
- `--json --verbose`: single array of post-mutation items matching read-command JSON shape.
- Covers `clarify update`/`discard`, `organize move`/`link`/`schedule`, `engage done`/`cancel`, `item update`/`archive`/`restore`. Commands that already print on success (`capture add`, `organize promote`, `reflect tickler --pull`, `init`) are intentionally left alone.

Closes #26.

## Test plan

- [x] `mise run build`
- [x] `mise run test` — new coverage in `internal/output/output_test.go` (silent default, text, text bulk, JSON, helpers) and `internal/command/command_test.go` (default silent, engage done verbose text+JSON, organize schedule RFC3339 echo, move, link, clarify update/discard, item update multi-field, archive, restore)
- [x] `mise run lint`
- [x] Manual smoke against the built binary: default silent, `--verbose` one-liner, `--verbose --json` array