### PR TITLE
feat(organize): add unlink subcommand

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,7 +67,7 @@ Mutating commands (see below) exit silently on success by default, which keeps p
 Affected commands:
 
 - `htd clarify update` / `clarify discard`
-- `htd organize move` / `organize link` / `organize schedule`
+- `htd organize move` / `organize link` / `organize unlink` / `organize schedule`
 - `htd engage done` / `engage cancel`
 - `htd item update` / `item archive` / `item restore`
 
@@ -270,9 +270,29 @@ htd organize link ID --project PROJECT_ID
 2. Set the `project` field in the item's front matter.
 3. Set `updated_at` to the current timestamp.
 
-To unlink, pass `--project ""` (empty string).
+To unlink, use `htd organize unlink ID`. Passing `--project ""` is still accepted as a legacy alias and will be removed in a future release.
 
-### 4.3 `htd organize schedule`
+### 4.3 `htd organize unlink`
+
+Clear the project link on an item.
+
+```
+htd organize unlink ID
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `ID` | yes | The item ID whose `project` field should be cleared |
+
+**Behavior:**
+
+1. Find the item across all `items/<kind>/` directories.
+2. Clear the `project` field in the item's front matter.
+3. Set `updated_at` to the current timestamp.
+
+Idempotent: unlinking an item that is not currently linked to a project is a silent no-op (aside from bumping `updated_at`).
+
+### 4.4 `htd organize schedule`
 
 Set scheduling-related dates on an item.
 
@@ -295,7 +315,7 @@ At least one date option must be provided. To clear a date, pass `--due ""`.
 
 When a datetime is supplied, it is preserved to the second and `engage next-action` / `reflect next-actions` sort intra-day by the exact moment. A date-only value is interpreted as midnight in the local timezone.
 
-### 4.4 `htd organize promote`
+### 4.5 `htd organize promote`
 
 Promote an item to a project in one shot, creating and linking initial next-action children.
 
@@ -854,6 +874,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd clarify discard ID` | Discard an inbox item |
 | `htd organize move KIND ID [ID...]` | Change the category of one or more items |
 | `htd organize link ID --project PID` | Link item to a project |
+| `htd organize unlink ID` | Clear the project link on an item |
 | `htd organize schedule ID` | Set dates on an item |
 | `htd organize promote ID --child TITLE...` | Promote to a project with next-action children |
 | `htd reflect next-actions` | List active next actions |

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -459,6 +459,45 @@ func TestOrganizeLink(t *testing.T) {
 	}
 }
 
+func TestOrganizeUnlink(t *testing.T) {
+	dir := setupDir(t)
+	task := nowItem("20260423-u_task", model.KindNextAction, model.StatusActive)
+	task.Project = "20260423-u_proj"
+	writeItem(t, dir, task, "")
+
+	_, _, err := runCmd(t, dir, "organize", "unlink", "20260423-u_task")
+	if err != nil {
+		t.Fatalf("organize unlink: %v", err)
+	}
+
+	got, _ := readItem(t, dir, "20260423-u_task")
+	if got.Project != "" {
+		t.Errorf("project: want empty, got %q", got.Project)
+	}
+}
+
+func TestOrganizeUnlinkIdempotent(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260423-u_plain", model.KindNextAction, model.StatusActive), "")
+
+	if _, _, err := runCmd(t, dir, "organize", "unlink", "20260423-u_plain"); err != nil {
+		t.Fatalf("organize unlink on unlinked item: %v", err)
+	}
+
+	got, _ := readItem(t, dir, "20260423-u_plain")
+	if got.Project != "" {
+		t.Errorf("project: want empty, got %q", got.Project)
+	}
+}
+
+func TestOrganizeUnlinkNotFound(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "organize", "unlink", "20260423-missing")
+	if !store.IsNotFound(err) {
+		t.Errorf("expected NotFoundError, got %v", err)
+	}
+}
+
 func TestOrganizeSchedule(t *testing.T) {
 	dir := setupDir(t)
 	writeItem(t, dir, nowItem("20260417-sched", model.KindNextAction, model.StatusActive), "")
@@ -2259,6 +2298,22 @@ func TestOrganizeLinkVerbose(t *testing.T) {
 		t.Fatalf("organize link -v: %v", err)
 	}
 	want := "updated 20260421-vt: project=20260421-vp\n"
+	if out != want {
+		t.Errorf("want %q, got %q", want, out)
+	}
+}
+
+func TestOrganizeUnlinkVerbose(t *testing.T) {
+	dir := setupDir(t)
+	task := nowItem("20260423-vu_task", model.KindNextAction, model.StatusActive)
+	task.Project = "20260423-vu_proj"
+	writeItem(t, dir, task, "")
+
+	out, _, err := runCmd(t, dir, "-v", "organize", "unlink", "20260423-vu_task")
+	if err != nil {
+		t.Fatalf("organize unlink -v: %v", err)
+	}
+	want := "updated 20260423-vu_task: project=\n"
 	if out != want {
 		t.Errorf("want %q, got %q", want, out)
 	}

--- a/internal/command/organize.go
+++ b/internal/command/organize.go
@@ -20,6 +20,7 @@ func newOrganizeCommand(c *container) *cobra.Command {
 	cmd.AddCommand(
 		newOrganizeMoveCommand(c),
 		newOrganizeLinkCommand(c),
+		newOrganizeUnlinkCommand(c),
 		newOrganizeScheduleCommand(c),
 		newOrganizePromoteCommand(c),
 	)
@@ -134,6 +135,36 @@ func newOrganizeLinkCommand(c *container) *cobra.Command {
 	cmd.Flags().StringVar(&projectID, "project", "", "Project ID to link to (empty string to unlink)")
 	_ = cmd.MarkFlagRequired("project")
 	return cmd
+}
+
+func newOrganizeUnlinkCommand(c *container) *cobra.Command {
+	return &cobra.Command{
+		Use:   "unlink ID",
+		Short: "Clear the project link on an item",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			itemID := args[0]
+
+			path, err := store.FindItem(c.cfg, itemID)
+			if err != nil {
+				return err
+			}
+			item, body, err := store.Read(path)
+			if err != nil {
+				return err
+			}
+			item.Project = ""
+			item.UpdatedAt = time.Now()
+			if err := store.Write(path, item, body); err != nil {
+				return err
+			}
+			c.printer.PrintUpdates([]output.Update{{
+				Item:    item,
+				Changes: []output.Change{{Key: "project", Value: ""}},
+			}})
+			return nil
+		},
+	}
 }
 
 func newOrganizeScheduleCommand(c *container) *cobra.Command {


### PR DESCRIPTION
## Summary

- Add `htd organize unlink ID` subcommand so clearing a project link is discoverable from `--help` rather than hidden behind the `--project ""` sentinel on `organize link`.
- Wire the new command through the shared verbose-output pipeline (`updated <id>: project=` / JSON item in `-v` mode).
- Keep `htd organize link ID --project ""` working as a legacy alias; docs now flag it as deprecated in favor of `unlink`.
- Update `docs/cli.md` with the new section, the affected-by-`--verbose` list, and the command summary.

Unlink is idempotent: running it on an item that has no project set is a silent no-op (aside from `updated_at`), matching the prior `--project ""` semantics.

Closes #27

## Test plan

- [x] `mise run lint` — 0 issues
- [x] `mise run test` — full suite green, including new `TestOrganizeUnlink`, `TestOrganizeUnlinkIdempotent`, `TestOrganizeUnlinkNotFound`, `TestOrganizeUnlinkVerbose`
- [x] `mise run build` then `./bin/htd organize --help` lists `unlink`