### PR TITLE
docs(item): document supported fields in `item update --help`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -721,24 +721,53 @@ htd item list --kind next_action --query 'tag:bug'
 
 ### 7.3 `htd item update`
 
-Update arbitrary fields on an item.
+Update fields on an item. Each argument is a `FIELD=VALUE` pair; multiple pairs are applied in order and written in a single file update.
 
 ```
 htd item update ID FIELD=VALUE [FIELD=VALUE]...
 ```
 
-**Behavior:**
+**Supported fields:**
 
-1. Find the item by ID.
-2. Update each specified front matter field.
-3. Set `updated_at` to the current timestamp.
-4. If `kind` is changed, move the file to the appropriate directory.
-5. If `status` is changed to a non-active status, move to `archive/items/`.
+| Field | Format | Notes |
+|-------|--------|-------|
+| `title` | string | Short description |
+| `body` | string | Markdown body (the content after front matter, not a front-matter field itself) |
+| `kind` | enum | One of `inbox`, `next_action`, `project`, `waiting_for`, `someday`, `tickler` |
+| `status` | enum | One of `active`, `done`, `canceled`, `discarded`, `archived` |
+| `project` | string | ID of a project-kind item |
+| `source` | string | Origin string (e.g., `manual`, `email`, `slack`) |
+| `tags` | list | Comma-separated, optionally bracketed: `foo,bar` or `[foo,bar]`. Pass `tags=` (empty) to clear. |
+| `refs` | list | Comma-separated URL list; same syntax as `tags`. |
+| `due_at` | date / datetime | `YYYY-MM-DD` or RFC 3339 (e.g., `2026-05-01T14:30:00+09:00`). Pass `due_at=` to clear. |
+| `defer_until` | date / datetime | Same format as `due_at`. |
+| `review_at` | date | Same format as `due_at`. |
+
+Unknown fields are rejected with an error that lists the supported fields.
 
 **Protected fields** (cannot be changed):
 
 - `id`
 - `created_at`
+
+**Behavior:**
+
+1. Find the item by ID.
+2. Update each specified front matter field (or body, for `body=`).
+3. Set `updated_at` to the current timestamp.
+4. If `kind` is changed, move the file to the appropriate directory.
+5. If `status` is changed to a non-active status, move to `archive/items/`.
+
+**Cross-references:**
+
+`item update` is the low-level CRUD entry point (see §7 intro). For the normal workflow, prefer the dedicated commands:
+
+- `organize schedule` — set `due_at` / `defer_until` / `review_at`
+- `organize link` / `organize unlink` — set or clear `project`
+- `organize move` — change `kind`
+- `engage done` / `engage cancel` / `item archive` / `item restore` — change `status`
+
+Scheduling, linking, and kind changes are accepted here as well so that scripts and agents can set several fields in one call; humans working through the five-phase workflow should reach for the workflow commands instead.
 
 **Examples:**
 
@@ -746,6 +775,7 @@ htd item update ID FIELD=VALUE [FIELD=VALUE]...
 $ htd item update 20260417-write_the_man_page kind=next_action
 $ htd item update 20260417-write_the_man_page tags='[cli,docs,v1]'
 $ htd item update 20260417-write_the_man_page refs='[https://github.com/foo/bar/pull/42]'
+$ htd item update 20260417-write_the_man_page due_at=2026-05-01 body="Draft outline first."
 ```
 
 ### 7.4 `htd item archive`

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1903,6 +1903,127 @@ func TestItemUpdateRefsField(t *testing.T) {
 	}
 }
 
+func TestItemUpdateDueAt(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-iu_due", model.KindNextAction, model.StatusActive), "")
+
+	const input = "2026-05-01T14:30:00+09:00"
+	if _, _, err := runCmd(t, dir, "item", "update", "20260417-iu_due", "due_at="+input); err != nil {
+		t.Fatalf("item update due_at: %v", err)
+	}
+
+	want, _ := time.Parse(time.RFC3339, input)
+	got, _ := readItem(t, dir, "20260417-iu_due")
+	if got.DueAt == nil || !got.DueAt.Equal(want) {
+		t.Errorf("due_at: want %s, got %v", want, got.DueAt)
+	}
+
+	if _, _, err := runCmd(t, dir, "item", "update", "20260417-iu_due", "due_at="); err != nil {
+		t.Fatalf("item update due_at= (clear): %v", err)
+	}
+	got, _ = readItem(t, dir, "20260417-iu_due")
+	if got.DueAt != nil {
+		t.Errorf("due_at: want nil after clear, got %s", got.DueAt)
+	}
+}
+
+func TestItemUpdateDeferUntil(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-iu_defer", model.KindNextAction, model.StatusActive), "")
+
+	if _, _, err := runCmd(t, dir, "item", "update", "20260417-iu_defer", "defer_until=2026-04-27"); err != nil {
+		t.Fatalf("item update defer_until: %v", err)
+	}
+	got, _ := readItem(t, dir, "20260417-iu_defer")
+	if got.DeferUntil == nil {
+		t.Fatal("defer_until: want non-nil, got nil")
+	}
+	if y, m, d := got.DeferUntil.Date(); y != 2026 || m != time.April || d != 27 {
+		t.Errorf("defer_until date: want 2026-04-27, got %04d-%02d-%02d", y, m, d)
+	}
+}
+
+func TestItemUpdateReviewAt(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-iu_rev", model.KindProject, model.StatusActive), "")
+
+	if _, _, err := runCmd(t, dir, "item", "update", "20260417-iu_rev", "review_at=2026-05-15"); err != nil {
+		t.Fatalf("item update review_at: %v", err)
+	}
+	got, _ := readItem(t, dir, "20260417-iu_rev")
+	if got.ReviewAt == nil {
+		t.Fatal("review_at: want non-nil, got nil")
+	}
+	if y, m, d := got.ReviewAt.Date(); y != 2026 || m != time.May || d != 15 {
+		t.Errorf("review_at date: want 2026-05-15, got %04d-%02d-%02d", y, m, d)
+	}
+}
+
+func TestItemUpdateUnknownField(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-iu_unk", model.KindInbox, model.StatusActive), "")
+
+	_, _, err := runCmd(t, dir, "item", "update", "20260417-iu_unk", "titel=Oops")
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `unknown field "titel"`) {
+		t.Errorf("error should name the unknown field, got: %v", err)
+	}
+	if !strings.Contains(msg, "supported:") || !strings.Contains(msg, "title") || !strings.Contains(msg, "due_at") {
+		t.Errorf("error should list supported fields, got: %v", err)
+	}
+}
+
+func TestItemUpdateProtectedField(t *testing.T) {
+	dir := setupDir(t)
+	writeItem(t, dir, nowItem("20260417-iu_prot", model.KindInbox, model.StatusActive), "")
+
+	for _, field := range []string{"id", "created_at"} {
+		_, _, err := runCmd(t, dir, "item", "update", "20260417-iu_prot", field+"=whatever")
+		if err == nil {
+			t.Errorf("%s=: expected error, got nil", field)
+			continue
+		}
+		if !strings.Contains(err.Error(), "protected") {
+			t.Errorf("%s=: error should mention 'protected', got: %v", field, err)
+		}
+	}
+
+	got, _ := readItem(t, dir, "20260417-iu_prot")
+	if got.ID != "20260417-iu_prot" {
+		t.Errorf("id should be unchanged, got %q", got.ID)
+	}
+}
+
+func TestItemUpdateBody(t *testing.T) {
+	dir := setupDir(t)
+	item := nowItem("20260417-iu_body", model.KindNextAction, model.StatusActive)
+	// Sleep 1 ms-ish gap so updated_at strictly moves forward.
+	item.UpdatedAt = item.UpdatedAt.Add(-time.Second)
+	writeItem(t, dir, item, "original body\n")
+	before := item.UpdatedAt
+
+	if _, _, err := runCmd(t, dir, "item", "update", "20260417-iu_body", "body=rewritten body"); err != nil {
+		t.Fatalf("item update body=: %v", err)
+	}
+
+	got, body := readItem(t, dir, "20260417-iu_body")
+	if !strings.Contains(body, "rewritten body") {
+		t.Errorf("body should be rewritten, got %q", body)
+	}
+	if strings.Contains(body, "original body") {
+		t.Errorf("body should not retain original, got %q", body)
+	}
+	if !got.UpdatedAt.After(before) {
+		t.Errorf("updated_at should advance: before=%s after=%s", before, got.UpdatedAt)
+	}
+	if got.Title != "20260417-iu_body" {
+		t.Errorf("title should be unchanged, got %q", got.Title)
+	}
+}
+
 func TestItemArchive(t *testing.T) {
 	dir := setupDir(t)
 	writeItem(t, dir, nowItem("20260417-arch", model.KindNextAction, model.StatusActive), "")

--- a/internal/command/item.go
+++ b/internal/command/item.go
@@ -116,10 +116,51 @@ func newItemListCommand(c *container) *cobra.Command {
 	return cmd
 }
 
+// itemUpdateFields lists the field names accepted by `htd item update`, in
+// the order shown in help text. Keep this list aligned with applyField.
+var itemUpdateFields = []string{
+	"title", "body", "kind", "status", "project", "source",
+	"tags", "refs", "due_at", "defer_until", "review_at",
+}
+
+const itemUpdateLong = `Update fields on an item.
+
+Each argument is a FIELD=VALUE pair. Multiple pairs are applied in order and
+written atomically in a single file update.
+
+Supported fields:
+  title        Short description.
+  body         Detailed description (Markdown; the content after front matter).
+  kind         One of: inbox, next_action, project, waiting_for, someday, tickler.
+  status       One of: active, done, canceled, discarded, archived.
+  project      ID of a project-kind item.
+  source       Origin string (e.g., manual, email, slack).
+  tags         Comma-separated list, optionally bracketed: foo,bar or [foo,bar].
+               Pass tags= (empty) to clear.
+  refs         Comma-separated URL list, same syntax as tags.
+  due_at       YYYY-MM-DD or RFC3339 (e.g., 2026-05-01T14:30:00+09:00).
+               Pass due_at= (empty) to clear.
+  defer_until  Same format as due_at.
+  review_at    Same format as due_at.
+
+Protected fields (cannot be changed): id, created_at.
+
+For the normal workflow, prefer the dedicated commands:
+  organize schedule               set due_at / defer_until / review_at
+  organize link / organize unlink set or clear project
+  organize move                   change kind
+  engage done / engage cancel     mark terminal
+  item archive / item restore     other status transitions
+
+Use item update for scripting, automation, and agent use where setting several
+fields in one call is more convenient than invoking the workflow commands
+separately.`
+
 func newItemUpdateCommand(c *container) *cobra.Command {
 	return &cobra.Command{
 		Use:   "update ID FIELD=VALUE...",
 		Short: "Update arbitrary fields on an item",
+		Long:  itemUpdateLong,
 		Args:  cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			itemID := args[0]
@@ -260,7 +301,7 @@ func applyField(item *model.Item, body *string, key, value string) error {
 	case "body":
 		*body = value
 	default:
-		return fmt.Errorf("unknown field %q", key)
+		return fmt.Errorf("unknown field %q (supported: %s)", key, strings.Join(itemUpdateFields, ", "))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add a Cobra `Long` description to `htd item update` that enumerates the 11 supported fields, their value formats, the protected fields (`id`, `created_at`), and the workflow commands humans should reach for instead (`organize schedule` / `link` / `unlink` / `move`, `engage done` / `cancel`, `item archive` / `restore`).
- Improve the `unknown field` error to list the supported fields in the same order.
- Expand `docs/cli.md` §7.3 with a field table and a cross-references section.
- Add tests for scheduling fields via `item update` (`due_at`, `defer_until`, `review_at`), the `body` rewrite path, the new unknown-field error shape, and protected-field rejection. These close coverage gaps surfaced during planning.

## Open question resolution

The issue asked whether scheduling fields should remain updatable via `item update` or be restricted to `organize schedule`. This PR keeps them updatable here: the `item` group is explicitly the low-level CRUD entry point for scripts and agents (PRD §6, `docs/cli.md` §7), and carving out a special case for scheduling fields would break atomic multi-field updates and be inconsistent with `kind` / `project`, which are already accepted. The help text and docs both document `organize schedule` as the preferred path for the human workflow.

## Test plan

- [x] `mise run build`
- [x] `mise run test`
- [x] `mise run lint`
- [x] Manually verify `./bin/htd item update --help` renders the new description.
- [x] Manually verify `./bin/htd item update <id> titel=foo` error lists supported fields.

Closes #28.