### PR TITLE
feat(engage): rename `next-action` to `next-actions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ htd reflect done --since DATE
 ### Engage
 
 ```
-htd engage next-action [--project PROJECT_ID] [--tag TAG]...
+htd engage next-actions [--project PROJECT_ID] [--tag TAG]...
 htd engage waiting [--stale-days N]
 htd engage tickler
 htd engage done ID [ID...]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -313,7 +313,7 @@ htd organize schedule ID [--due DATE] [--defer DATE] [--review DATE]
 
 At least one date option must be provided. To clear a date, pass `--due ""`.
 
-When a datetime is supplied, it is preserved to the second and `engage next-action` / `reflect next-actions` sort intra-day by the exact moment. A date-only value is interpreted as midnight in the local timezone.
+When a datetime is supplied, it is preserved to the second and `engage next-actions` / `reflect next-actions` sort intra-day by the exact moment. A date-only value is interpreted as midnight in the local timezone.
 
 ### 4.5 `htd organize promote`
 
@@ -553,12 +553,12 @@ htd engage cancel ID [ID...]
 - Only active items can be canceled.
 - `inbox` items can also be canceled via this command, though `clarify discard` is preferred for inbox items that were never actionable.
 
-### 6.3 `htd engage next-action`
+### 6.3 `htd engage next-actions`
 
 List next actions that are ready to work on now.
 
 ```
-htd engage next-action [--project PROJECT_ID] [--tag TAG]...
+htd engage next-actions [--project PROJECT_ID] [--tag TAG]...
 ```
 
 | Option | Required | Description |
@@ -574,7 +574,14 @@ htd engage next-action [--project PROJECT_ID] [--tag TAG]...
 4. Display: `ID`, `TITLE`, `PROJECT`, `DUE_AT`.
 5. Sort by `due_at` ascending (items without due dates last). Datetimes sort by their exact moment; date-only values sort as midnight local time.
 
-This command overlaps with `reflect next-actions` in content; the difference is intent (Engage = pick work; Reflect = review system) plus the filter flags above.
+All list-returning commands in this CLI use the plural form that matches the list they query. `engage next-actions` and `reflect next-actions` both return the same shape of list; the difference between them is mechanical, not judgment-based:
+
+- `reflect next-actions` is the survey view of the full list.
+- `engage next-actions` is the narrowing view for picking work right now, via `--project` and `--tag` (and future mechanical predicates such as parent-project activity).
+
+Priority, context, time, and energy are not applied inside `htd` — those judgments stay with the caller, who can compose a `--query` expression on `item list`, pipe the JSON, or scan the returned list by eye.
+
+The previous singular alias `htd engage next-action` is still accepted but prints a deprecation warning; update scripts to the plural form.
 
 ### 6.4 `htd engage waiting`
 
@@ -915,7 +922,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd reflect tickler [--pull]` | List fired tickler items, or pull them into the inbox |
 | `htd engage done ID [ID...]` | Mark one or more items as done |
 | `htd engage cancel ID [ID...]` | Cancel one or more active items |
-| `htd engage next-action` | List next actions ready to work on now |
+| `htd engage next-actions` | List next actions ready to work on now |
 | `htd engage waiting` | List waiting-for items that need follow-up |
 | `htd item get ID` | Get any item by ID |
 | `htd item list` | List items with filters (supports `--query` DSL) |

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -570,9 +570,9 @@ func TestOrganizeScheduleRFC3339Defer(t *testing.T) {
 		t.Errorf("defer_until: want %s, got %s", wantFuture, got.DeferUntil)
 	}
 
-	out, _, err := runCmd(t, dir, "engage", "next-action")
+	out, _, err := runCmd(t, dir, "engage", "next-actions")
 	if err != nil {
-		t.Fatalf("engage next-action: %v", err)
+		t.Fatalf("engage next-actions: %v", err)
 	}
 	if strings.Contains(out, "20260417-rfc_defer_future") {
 		t.Errorf("item with defer_until in the future should be hidden: %q", out)
@@ -599,9 +599,9 @@ func TestEngageNextActionSortsIntraDay(t *testing.T) {
 	writeItem(t, dir, m, "")
 	writeItem(t, dir, a, "")
 
-	out, _, err := runCmd(t, dir, "engage", "next-action")
+	out, _, err := runCmd(t, dir, "engage", "next-actions")
 	if err != nil {
-		t.Fatalf("engage next-action: %v", err)
+		t.Fatalf("engage next-actions: %v", err)
 	}
 
 	want := []string{
@@ -904,9 +904,9 @@ func TestEngageNextAction(t *testing.T) {
 	deferred.DeferUntil = &future
 	writeItem(t, dir, deferred, "")
 
-	out, _, err := runCmd(t, dir, "engage", "next-action")
+	out, _, err := runCmd(t, dir, "engage", "next-actions")
 	if err != nil {
-		t.Fatalf("engage next-action: %v", err)
+		t.Fatalf("engage next-actions: %v", err)
 	}
 	if !strings.Contains(out, "20260417-na_ready") {
 		t.Errorf("missing ready next action: %q", out)
@@ -938,9 +938,9 @@ func TestEngageNextActionIncludesDueToday(t *testing.T) {
 	upcoming.DueAt = &future
 	writeItem(t, dir, upcoming, "")
 
-	out, _, err := runCmd(t, dir, "engage", "next-action")
+	out, _, err := runCmd(t, dir, "engage", "next-actions")
 	if err != nil {
-		t.Fatalf("engage next-action: %v", err)
+		t.Fatalf("engage next-actions: %v", err)
 	}
 	for _, id := range []string{"20260420-due_today", "20260420-overdue", "20260420-upcoming"} {
 		if !strings.Contains(out, id) {
@@ -968,9 +968,9 @@ func TestEngageNextActionSortsByDueAt(t *testing.T) {
 	writeItem(t, dir, c, "")
 	writeItem(t, dir, d, "")
 
-	out, _, err := runCmd(t, dir, "engage", "next-action")
+	out, _, err := runCmd(t, dir, "engage", "next-actions")
 	if err != nil {
-		t.Fatalf("engage next-action: %v", err)
+		t.Fatalf("engage next-actions: %v", err)
 	}
 
 	want := []string{
@@ -1003,9 +1003,9 @@ func TestEngageNextActionShowsDueAtColumn(t *testing.T) {
 	it.Project = "20260420-some_proj"
 	writeItem(t, dir, it, "")
 
-	out, _, err := runCmd(t, dir, "engage", "next-action")
+	out, _, err := runCmd(t, dir, "engage", "next-actions")
 	if err != nil {
-		t.Fatalf("engage next-action: %v", err)
+		t.Fatalf("engage next-actions: %v", err)
 	}
 	if !strings.Contains(out, "DUE_AT") {
 		t.Errorf("header should include DUE_AT column: %q", out)
@@ -1030,9 +1030,9 @@ func TestEngageNextActionFilterProject(t *testing.T) {
 	writeItem(t, dir, a, "")
 	writeItem(t, dir, b, "")
 
-	out, _, err := runCmd(t, dir, "engage", "next-action", "--project", "20260417-proj_a")
+	out, _, err := runCmd(t, dir, "engage", "next-actions", "--project", "20260417-proj_a")
 	if err != nil {
-		t.Fatalf("engage next-action --project: %v", err)
+		t.Fatalf("engage next-actions --project: %v", err)
 	}
 	if !strings.Contains(out, "20260417-na_a") {
 		t.Errorf("missing project-a next action: %q", out)
@@ -1051,15 +1051,36 @@ func TestEngageNextActionFilterTag(t *testing.T) {
 	writeItem(t, dir, tagged, "")
 	writeItem(t, dir, other, "")
 
-	out, _, err := runCmd(t, dir, "engage", "next-action", "--tag", "urgent")
+	out, _, err := runCmd(t, dir, "engage", "next-actions", "--tag", "urgent")
 	if err != nil {
-		t.Fatalf("engage next-action --tag: %v", err)
+		t.Fatalf("engage next-actions --tag: %v", err)
 	}
 	if !strings.Contains(out, "20260417-na_tagged") {
 		t.Errorf("missing tagged next action: %q", out)
 	}
 	if strings.Contains(out, "20260417-na_other") {
 		t.Errorf("should not include untagged next action: %q", out)
+	}
+}
+
+func TestEngageNextActionDeprecatedAlias(t *testing.T) {
+	dir := setupDir(t)
+	it := nowItem("20260417-na_alias", model.KindNextAction, model.StatusActive)
+	writeItem(t, dir, it, "")
+
+	out, errOut, err := runCmd(t, dir, "engage", "next-action")
+	if err != nil {
+		t.Fatalf("engage next-action (deprecated): %v", err)
+	}
+	if !strings.Contains(out, "20260417-na_alias") {
+		t.Errorf("deprecated alias should still list items: %q", out)
+	}
+	combined := out + errOut
+	if !strings.Contains(combined, "deprecated") {
+		t.Errorf("deprecation warning expected in output, got stdout=%q stderr=%q", out, errOut)
+	}
+	if !strings.Contains(combined, "next-actions") {
+		t.Errorf("deprecation warning should point at 'next-actions', got stdout=%q stderr=%q", out, errOut)
 	}
 }
 

--- a/internal/command/engage.go
+++ b/internal/command/engage.go
@@ -21,7 +21,8 @@ func newEngageCommand(c *container) *cobra.Command {
 	cmd.AddCommand(
 		newEngageDoneCommand(c),
 		newEngageCancelCommand(c),
-		newEngageNextActionCommand(c),
+		newEngageNextActionsCommand(c),
+		newEngageNextActionDeprecatedCommand(c),
 		newEngageWaitingCommand(c),
 	)
 	return cmd
@@ -65,14 +66,29 @@ func runTerminate(c *container, ids []string, status model.Status) error {
 	return nil
 }
 
-func newEngageNextActionCommand(c *container) *cobra.Command {
+func newEngageNextActionsCommand(c *container) *cobra.Command {
+	cmd := buildEngageNextActionsCommand(c)
+	cmd.Use = "next-actions"
+	return cmd
+}
+
+// newEngageNextActionDeprecatedCommand keeps the old singular name working as a
+// hidden alias that prints a deprecation warning. Remove after one release cycle.
+func newEngageNextActionDeprecatedCommand(c *container) *cobra.Command {
+	cmd := buildEngageNextActionsCommand(c)
+	cmd.Use = "next-action"
+	cmd.Deprecated = `use "htd engage next-actions" instead`
+	cmd.Hidden = true
+	return cmd
+}
+
+func buildEngageNextActionsCommand(c *container) *cobra.Command {
 	var (
 		projectID string
 		tags      []string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "next-action",
 		Short: "List next actions ready to work on now",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kind := model.KindNextAction

--- a/plugins/htd/commands/engage.md
+++ b/plugins/htd/commands/engage.md
@@ -12,7 +12,7 @@ The user wants to act on their system. Give them an overview of what needs atten
 Run these three in parallel and parse the JSON:
 
 ```bash
-htd engage next-action --json
+htd engage next-actions --json
 htd engage waiting --json
 htd reflect tickler --json
 ```
@@ -37,8 +37,8 @@ Ask which category (or "done", "none") they want to dive into:
 
 Ask briefly about context and time: "How long do you have, and what kind of work fits right now (deep focus, quick wins, specific project)?" Use the answers to narrow:
 
-- For a specific project: `htd engage next-action --project <id> --json`.
-- For a tag/context: `htd engage next-action --tag <t> --json`.
+- For a specific project: `htd engage next-actions --project <id> --json`.
+- For a tag/context: `htd engage next-actions --tag <t> --json`.
 - No narrowing: use the existing list.
 
 Propose 1–3 candidates. Don't pick for the user. Once they choose, step back — they'll go work on it, and mark it done later with `htd engage done <id>`.

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -73,7 +73,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 - `htd reflect tickler [--pull]` — ticklers whose `defer_until` (or `review_at` fallback) is today or past. With `--pull`, move them into the inbox for re-clarification (clears `defer_until`, keeps `review_at`).
 
 **Engage** (act on the system)
-- `htd engage next-action [--project ID] [--tag T]...` — what's ready to work on now.
+- `htd engage next-actions [--project ID] [--tag T]...` — what's ready to work on now.
 - `htd engage waiting [--stale-days N]` — waiting-for items untouched ≥ N days (default 7). JSON includes `age_days`.
 - `htd engage done ID [ID...]` — accepts multiple IDs.
 - `htd engage cancel ID [ID...]` — accepts multiple IDs.


### PR DESCRIPTION
## Summary

- Rename `htd engage next-action` to `htd engage next-actions` so every list-returning command uses the plural form matching its list name.
- Keep `next-action` as a hidden, deprecated alias that prints a stderr warning via Cobra's `Deprecated` field. Remove after one release cycle.
- Update `docs/cli.md` (§6.3 heading, usage, command summary, and a short "reflect vs engage" note: both return the same list shape, `engage` adds narrowing flags; priority/context/time/energy judgments stay outside `htd`).
- Update `README.md`, `plugins/htd/commands/engage.md`, and `plugins/htd/skills/htd-workflow/SKILL.md`.
- Update the 8 tests that invoke the command and add `TestEngageNextActionDeprecatedAlias` covering the alias path + warning.

## Test plan

- [x] `mise run build`
- [x] `mise run test`
- [x] `mise run lint`
- [x] `./bin/htd --path /tmp/... engage next-actions` — renders the list.
- [x] `./bin/htd --path /tmp/... engage next-action 2>&1 >/dev/null` — the deprecation warning lands on stderr (`Command "next-action" is deprecated, use "htd engage next-actions" instead`).

Closes #29.