### PR TITLE
feat(reference): add archive and restore

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,7 +71,7 @@ Affected commands:
 - `htd organize move` / `organize link` / `organize unlink` / `organize schedule`
 - `htd engage done` / `engage cancel`
 - `htd item update` / `item archive` / `item restore`
-- `htd reference update`
+- `htd reference update` / `reference archive` / `reference restore`
 
 Commands that already print on success (`capture add`, `reference add`, `organize promote`, `reflect tickler --pull`, `init`) ignore `--verbose`; their output is unchanged.
 
@@ -882,33 +882,34 @@ htd reference get ID
 
 **Behavior:**
 
-1. Search across every tool directory under `reference/` and (in the future) `archive/reference/` for the given ID.
-2. Display the front matter and body.
+1. Search across every tool directory under `reference/`, then `archive/reference/`, for the given ID. Active hits win when both exist.
+2. Display the front matter and body. When the hit comes from the archive, prepend an `(archived)` line above the metadata block in text mode and set `archived: true` in `--json` mode (the field is omitted entirely for active hits).
 3. Exit with code `2` if the reference is not found.
 
-**JSON output:** A single object with the reference fields plus a `tool` field. The `archived: true` field is reserved for archive support and is omitted in v1 active hits.
+**JSON output:** A single object with the reference fields plus a `tool` field. `archived: true` appears only when the reference came from the archive.
 
 ### 8.3 `htd reference list`
 
-List active references for a tool.
+List references for a tool.
 
 ```
-htd reference list [--tool TOOL] [--tag TAG]
+htd reference list [--tool TOOL] [--tag TAG] [--archived]
 ```
 
 | Option | Required | Description |
 |--------|----------|-------------|
 | `--tool` | no | Tool namespace (default `claude`) |
 | `--tag` | no | Filter to references containing this exact tag |
+| `--archived` | no | List archived references under `archive/reference/<tool>/` instead of active ones |
 
 **Behavior:**
 
-1. Read all `*.md` files under `reference/<tool>/` (excluding `INDEX.md`).
+1. Read all `*.md` files under `reference/<tool>/` (excluding `INDEX.md`). When `--archived` is set, scan `archive/reference/<tool>/` instead — the active and archived views are mutually exclusive.
 2. Apply the `--tag` filter if given.
-3. Display columns: `ID`, `TOOL`, `UPDATED_AT`, `TITLE`.
+3. Display columns: `ID`, `TOOL`, `UPDATED_AT`, `TITLE`. Archived rows carry an `(archived)` prefix on the title column in text mode.
 4. Sort by `updated_at` descending, with `id` ascending as the deterministic tiebreaker.
 
-**JSON output:** Array of reference objects.
+**JSON output:** Array of reference objects. `archived: true` is set on every row when `--archived` is used.
 
 ### 8.4 `htd reference update`
 
@@ -934,12 +935,50 @@ htd reference update ID FIELD=VALUE [FIELD=VALUE]...
 
 **Behavior:**
 
-1. Find the reference by ID across every tool directory (active first, archive fallback for future archive support).
+1. Find the reference by ID across every tool directory (active first, archive fallback).
 2. Update each specified field in order.
 3. Set `updated_at` to the current timestamp.
-4. Rewrite the active `INDEX.md` for the owning tool (regrouping when `tags` changes the `type:*` tag).
+4. Rewrite the active `INDEX.md` for the owning tool when the reference is active (regrouping when `tags` changes the `type:*` tag). Archived references do not appear in `INDEX.md`, so the file is not rewritten when an archived reference is updated.
 
-### 8.5 `INDEX.md` format
+### 8.5 `htd reference archive`
+
+Archive a reference. Archival is location-only — references have no `status` field. The file moves from `reference/<tool>/<id>.md` to `archive/reference/<tool>/<id>.md` and the active `INDEX.md` is rewritten to drop the entry.
+
+```
+htd reference archive ID
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `ID` | yes | The reference ID |
+
+**Behavior:**
+
+1. Locate the reference. Archived references are rejected; archiving is one-way.
+2. Update `updated_at` to the current timestamp.
+3. Move the file to `archive/reference/<tool>/<id>.md`.
+4. Rewrite `reference/<tool>/INDEX.md`. When the last active reference for a tool is archived, INDEX.md falls back to the empty-state stub (the file is still written rather than deleted so archive-then-empty stays diff-clean).
+
+### 8.6 `htd reference restore`
+
+Restore an archived reference to active. Symmetric inverse of `archive`.
+
+```
+htd reference restore ID
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `ID` | yes | The reference ID |
+
+**Behavior:**
+
+1. Locate the reference. Active references are rejected.
+2. Update `updated_at` to the current timestamp.
+3. Move the file from `archive/reference/<tool>/<id>.md` back to `reference/<tool>/<id>.md`.
+4. Rewrite the active `INDEX.md`.
+
+### 8.7 `INDEX.md` format
 
 `reference/<tool>/INDEX.md` is generated by the `reference` commands and is treated as a scoped exception to `docs/datamodel.md §9` ("no generated index files"). The exception exists so AI sessions can recover context cheaply at startup without scanning the filesystem.
 
@@ -951,7 +990,9 @@ The format is fully deterministic — the same set of references produces a byte
 - Each entry is one bullet line: `- [title](id.md) — short description`. The "short description" is the first non-blank line of the body with leading `#` stripped, truncated to 80 runes. The em-dash and description are omitted when no usable description line exists.
 - When no references are present, the body is the empty-state stub `_No entries._` (the file is still written rather than deleted, so archive-then-empty stays diff-clean).
 
-### 8.6 `htd reference reindex`
+INDEX.md is active-only. Archived references do not appear; use `htd reference list --archived` to inspect the archive.
+
+### 8.8 `htd reference reindex`
 
 Rewrite `reference/<tool>/INDEX.md` from the current set of references. This is a repair verb only — the index is already kept in sync by every mutation; reach for `reindex` when the file diverged from disk through manual edits or merge conflicts.
 
@@ -966,7 +1007,7 @@ htd reference reindex [--tool TOOL]
 **Behavior:**
 
 1. Scan `reference/<tool>/` for active references.
-2. Render `INDEX.md` per §8.5 and write it atomically.
+2. Render `INDEX.md` per §8.7 and write it atomically.
 3. Idempotent: running `reindex` twice produces the same disk state.
 
 There is no `htd reference index` noun-verb — `htd reference list` already covers "show me what's there."
@@ -1075,8 +1116,10 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd item archive ID` | Archive an item (last resort) |
 | `htd item restore ID` | Restore a terminal item to active status |
 | `htd reference add` | Add a reference under `reference/<tool>/` |
-| `htd reference get ID` | Get a reference by ID |
-| `htd reference list` | List active references for a tool |
+| `htd reference get ID` | Get a reference by ID (with `(archived)` marker if applicable) |
+| `htd reference list [--archived]` | List active references for a tool, or archived ones |
 | `htd reference update ID` | Update reference fields |
+| `htd reference archive ID` | Archive a reference |
+| `htd reference restore ID` | Restore an archived reference |
 | `htd reference reindex` | Rewrite `reference/<tool>/INDEX.md` (repair) |
 | `htd completion SHELL` | Emit a shell completion script |

--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -167,7 +167,11 @@ The format is fully deterministic — same set of references → byte-for-byte i
 
 ### 3.5 Reference Archival
 
-References can be archived by moving them from `reference/<tool>/` to `archive/reference/<tool>/`. INDEX.md is active-only — archive removes the entry. CLI verbs for archive/restore are tracked separately (see issue #35).
+References can be archived by moving them from `reference/<tool>/` to `archive/reference/<tool>/`. Archival is location-only — references have no `status` field, so the move alone communicates the archived state.
+
+INDEX.md is active-only; archiving a reference removes it from the index, restoring puts it back. The CLI surface is `htd reference archive ID` and `htd reference restore ID` (symmetric inverses); `htd reference list --archived` shows the archive contents.
+
+`htd reference get ID` falls back to the archive automatically. When the hit comes from `archive/reference/<tool>/`, the output is marked: an `(archived)` line precedes the metadata block in text mode and `archived: true` is set in `--json` output (the field is omitted entirely on active hits).
 
 ---
 

--- a/internal/command/reference.go
+++ b/internal/command/reference.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/takai/htd/internal/config"
 	"github.com/takai/htd/internal/id"
 	"github.com/takai/htd/internal/model"
 	"github.com/takai/htd/internal/output"
@@ -29,6 +30,8 @@ func newReferenceCommand(c *container) *cobra.Command {
 		newReferenceGetCommand(c),
 		newReferenceListCommand(c),
 		newReferenceUpdateCommand(c),
+		newReferenceArchiveCommand(c),
+		newReferenceRestoreCommand(c),
 		newReferenceReindexCommand(c),
 	)
 	return cmd
@@ -110,14 +113,15 @@ func newReferenceGetCommand(c *container) *cobra.Command {
 
 func newReferenceListCommand(c *container) *cobra.Command {
 	var (
-		tool string
-		tag  string
+		tool     string
+		tag      string
+		archived bool
 	)
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List active references for a tool",
+		Short: "List references for a tool",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			refs, err := store.ListReferences(c.cfg, tool, false)
+			refs, err := listReferencesForView(c.cfg, tool, archived)
 			if err != nil {
 				return err
 			}
@@ -138,7 +142,28 @@ func newReferenceListCommand(c *container) *cobra.Command {
 	}
 	addToolFlag(cmd, &tool)
 	cmd.Flags().StringVar(&tag, "tag", "", "Filter by tag")
+	cmd.Flags().BoolVar(&archived, "archived", false, "List archived references instead of active ones")
 	return cmd
+}
+
+// listReferencesForView returns active references when archived=false, or
+// archived ones when archived=true. The active list does not bleed into the
+// archived view and vice versa, matching the docs/cli.md §8.3 contract.
+func listReferencesForView(cfg *config.Config, tool string, archived bool) ([]store.ReferenceWithBody, error) {
+	if !archived {
+		return store.ListReferences(cfg, tool, false)
+	}
+	all, err := store.ListReferences(cfg, tool, true)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]store.ReferenceWithBody, 0, len(all))
+	for _, r := range all {
+		if r.Archived {
+			out = append(out, r)
+		}
+	}
+	return out, nil
 }
 
 const referenceUpdateLong = `Update fields on a reference.
@@ -206,6 +231,78 @@ func newReferenceUpdateCommand(c *container) *cobra.Command {
 				Tool:      res.Tool,
 				Archived:  res.Archived,
 				Changes:   changes,
+			}})
+			return nil
+		},
+	}
+}
+
+func newReferenceArchiveCommand(c *container) *cobra.Command {
+	return &cobra.Command{
+		Use:   "archive ID",
+		Short: "Archive a reference (move to archive/reference/<tool>/)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			refID := args[0]
+			res, err := store.FindReference(c.cfg, refID)
+			if err != nil {
+				return err
+			}
+			if res.Archived {
+				return fmt.Errorf("reference %q is already archived", refID)
+			}
+			ref, body, err := store.ReadRef(res.Path)
+			if err != nil {
+				return err
+			}
+			ref.UpdatedAt = time.Now()
+			if err := store.ArchiveReference(c.cfg, res.Tool, ref, body); err != nil {
+				return err
+			}
+			if err := store.WriteIndex(c.cfg, res.Tool); err != nil {
+				return err
+			}
+			c.printer.PrintReferenceUpdates([]output.ReferenceUpdate{{
+				Reference: ref,
+				Tool:      res.Tool,
+				Archived:  true,
+				Changes:   []output.Change{{Key: "archived", Value: "true"}},
+			}})
+			return nil
+		},
+	}
+}
+
+func newReferenceRestoreCommand(c *container) *cobra.Command {
+	return &cobra.Command{
+		Use:   "restore ID",
+		Short: "Restore an archived reference to active",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			refID := args[0]
+			res, err := store.FindReference(c.cfg, refID)
+			if err != nil {
+				return err
+			}
+			if !res.Archived {
+				return fmt.Errorf("reference %q is not archived", refID)
+			}
+			ref, body, err := store.ReadRef(res.Path)
+			if err != nil {
+				return err
+			}
+			ref.UpdatedAt = time.Now()
+			if err := store.RestoreReference(c.cfg, res.Tool, ref, body); err != nil {
+				return err
+			}
+			if err := store.WriteIndex(c.cfg, res.Tool); err != nil {
+				return err
+			}
+			c.printer.PrintReferenceUpdates([]output.ReferenceUpdate{{
+				Reference: ref,
+				Tool:      res.Tool,
+				Archived:  false,
+				Changes:   []output.Change{{Key: "archived", Value: "false"}},
 			}})
 			return nil
 		},

--- a/internal/command/reference_command_test.go
+++ b/internal/command/reference_command_test.go
@@ -303,6 +303,260 @@ func TestReferenceUpdateVerbose(t *testing.T) {
 	}
 }
 
+// ---------- reference archive ----------
+
+func TestReferenceArchiveMovesFileAndUpdatesIndex(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	writeReference(t, dir, "claude",
+		&model.Reference{ID: "r1", Title: "Doomed", CreatedAt: now, UpdatedAt: now, Tags: []string{"type:user"}},
+		"fact line",
+	)
+	cfg := config.New(dir)
+	if err := store.WriteIndex(cfg, "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := runCmd(t, dir, "reference", "archive", "r1"); err != nil {
+		t.Fatalf("reference archive: %v", err)
+	}
+
+	// File moved.
+	activePath := store.PathForReferenceActive(cfg, "claude", "r1")
+	if _, err := os.Stat(activePath); !os.IsNotExist(err) {
+		t.Errorf("active file still exists after archive: err=%v", err)
+	}
+	archivePath := store.PathForReferenceArchive(cfg, "claude", "r1")
+	if _, err := os.Stat(archivePath); err != nil {
+		t.Errorf("archive file missing: %v", err)
+	}
+
+	// INDEX.md no longer lists the entry; falls back to the empty stub.
+	idx := filepath.Join(cfg.ReferenceToolDir("claude"), "INDEX.md")
+	data, err := os.ReadFile(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "Doomed") {
+		t.Errorf("expected Doomed removed from INDEX.md:\n%s", data)
+	}
+	if !strings.Contains(string(data), "_No entries._") {
+		t.Errorf("expected empty stub in INDEX.md:\n%s", data)
+	}
+}
+
+func TestReferenceArchiveRefusesAlreadyArchived(t *testing.T) {
+	dir := setupDir(t)
+	cfg := config.New(dir)
+	now := time.Now()
+	ref := &model.Reference{ID: "r1", Title: "T", CreatedAt: now, UpdatedAt: now}
+	if err := store.WriteRef(store.PathForReferenceArchive(cfg, "claude", ref.ID), ref, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runCmd(t, dir, "reference", "archive", "r1"); err == nil {
+		t.Fatal("expected error when archiving already-archived reference")
+	}
+}
+
+func TestReferenceArchiveNotFound(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "reference", "archive", "ghost")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !store.IsNotFound(err) {
+		t.Errorf("expected NotFoundError, got %T %v", err, err)
+	}
+}
+
+func TestReferenceArchiveVerbose(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	writeReference(t, dir, "claude", &model.Reference{ID: "r1", Title: "T", CreatedAt: now, UpdatedAt: now}, "")
+	out, _, err := runCmd(t, dir, "--verbose", "reference", "archive", "r1")
+	if err != nil {
+		t.Fatalf("archive --verbose: %v", err)
+	}
+	if !strings.Contains(out, "updated r1: archived=true") {
+		t.Errorf("expected archived=true line, got:\n%s", out)
+	}
+}
+
+// ---------- reference restore ----------
+
+func TestReferenceRestoreMovesFileAndUpdatesIndex(t *testing.T) {
+	dir := setupDir(t)
+	cfg := config.New(dir)
+	now := time.Now()
+	ref := &model.Reference{ID: "r1", Title: "Restored", CreatedAt: now, UpdatedAt: now, Tags: []string{"type:user"}}
+	if err := store.WriteRef(store.PathForReferenceArchive(cfg, "claude", ref.ID), ref, "fact"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.WriteIndex(cfg, "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := runCmd(t, dir, "reference", "restore", "r1"); err != nil {
+		t.Fatalf("reference restore: %v", err)
+	}
+
+	activePath := store.PathForReferenceActive(cfg, "claude", "r1")
+	if _, err := os.Stat(activePath); err != nil {
+		t.Errorf("active file missing after restore: %v", err)
+	}
+	archivePath := store.PathForReferenceArchive(cfg, "claude", "r1")
+	if _, err := os.Stat(archivePath); !os.IsNotExist(err) {
+		t.Errorf("archive file still exists after restore: err=%v", err)
+	}
+	idx := filepath.Join(cfg.ReferenceToolDir("claude"), "INDEX.md")
+	data, err := os.ReadFile(idx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "Restored") {
+		t.Errorf("expected Restored back in INDEX.md:\n%s", data)
+	}
+}
+
+func TestReferenceRestoreRefusesActive(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	writeReference(t, dir, "claude", &model.Reference{ID: "r1", Title: "T", CreatedAt: now, UpdatedAt: now}, "")
+	if _, _, err := runCmd(t, dir, "reference", "restore", "r1"); err == nil {
+		t.Fatal("expected error when restoring active reference")
+	}
+}
+
+func TestReferenceRestoreVerbose(t *testing.T) {
+	dir := setupDir(t)
+	cfg := config.New(dir)
+	now := time.Now()
+	ref := &model.Reference{ID: "r1", Title: "T", CreatedAt: now, UpdatedAt: now}
+	if err := store.WriteRef(store.PathForReferenceArchive(cfg, "claude", ref.ID), ref, ""); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmd(t, dir, "--verbose", "reference", "restore", "r1")
+	if err != nil {
+		t.Fatalf("restore --verbose: %v", err)
+	}
+	if !strings.Contains(out, "updated r1: archived=false") {
+		t.Errorf("expected archived=false line, got:\n%s", out)
+	}
+}
+
+// ---------- reference list --archived ----------
+
+func TestReferenceListExcludesArchivedByDefault(t *testing.T) {
+	dir := setupDir(t)
+	cfg := config.New(dir)
+	now := time.Now()
+	writeReference(t, dir, "claude", &model.Reference{ID: "active1", Title: "A", CreatedAt: now, UpdatedAt: now}, "")
+	if err := store.WriteRef(store.PathForReferenceArchive(cfg, "claude", "arch1"),
+		&model.Reference{ID: "arch1", Title: "Arch", CreatedAt: now, UpdatedAt: now}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCmd(t, dir, "reference", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "active1") {
+		t.Errorf("expected active1 in default listing:\n%s", out)
+	}
+	if strings.Contains(out, "arch1") {
+		t.Errorf("archived entry leaked into default listing:\n%s", out)
+	}
+}
+
+func TestReferenceListArchivedShowsOnlyArchived(t *testing.T) {
+	dir := setupDir(t)
+	cfg := config.New(dir)
+	now := time.Now()
+	writeReference(t, dir, "claude", &model.Reference{ID: "active1", Title: "A", CreatedAt: now, UpdatedAt: now}, "")
+	if err := store.WriteRef(store.PathForReferenceArchive(cfg, "claude", "arch1"),
+		&model.Reference{ID: "arch1", Title: "Arch", CreatedAt: now, UpdatedAt: now}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCmd(t, dir, "reference", "list", "--archived")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "arch1") {
+		t.Errorf("expected arch1 in --archived listing:\n%s", out)
+	}
+	if strings.Contains(out, "active1") {
+		t.Errorf("active entry leaked into --archived listing:\n%s", out)
+	}
+	if !strings.Contains(out, "(archived)") {
+		t.Errorf("expected (archived) marker in row:\n%s", out)
+	}
+}
+
+func TestReferenceListArchivedJSON(t *testing.T) {
+	dir := setupDir(t)
+	cfg := config.New(dir)
+	now := time.Now()
+	if err := store.WriteRef(store.PathForReferenceArchive(cfg, "claude", "arch1"),
+		&model.Reference{ID: "arch1", Title: "Arch", CreatedAt: now, UpdatedAt: now}, ""); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmd(t, dir, "--json", "reference", "list", "--archived")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len: want 1, got %d", len(got))
+	}
+	if got[0]["archived"] != true {
+		t.Errorf("archived: want true, got %v", got[0]["archived"])
+	}
+}
+
+// ---------- reference get archive marker ----------
+
+func TestReferenceGetArchivedMarker(t *testing.T) {
+	dir := setupDir(t)
+	cfg := config.New(dir)
+	now := time.Now()
+	if err := store.WriteRef(store.PathForReferenceArchive(cfg, "claude", "r1"),
+		&model.Reference{ID: "r1", Title: "Old", CreatedAt: now, UpdatedAt: now}, "body"); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmd(t, dir, "reference", "get", "r1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !strings.HasPrefix(out, "(archived)\n") {
+		t.Errorf("expected (archived) prefix line, got:\n%s", out)
+	}
+}
+
+func TestReferenceGetArchivedJSON(t *testing.T) {
+	dir := setupDir(t)
+	cfg := config.New(dir)
+	now := time.Now()
+	if err := store.WriteRef(store.PathForReferenceArchive(cfg, "claude", "r1"),
+		&model.Reference{ID: "r1", Title: "Old", CreatedAt: now, UpdatedAt: now}, "body"); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCmd(t, dir, "--json", "reference", "get", "r1")
+	if err != nil {
+		t.Fatalf("get --json: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if got["archived"] != true {
+		t.Errorf("archived: want true, got %v", got["archived"])
+	}
+}
+
 // ---------- reference reindex ----------
 
 func TestReferenceReindex(t *testing.T) {

--- a/internal/store/reference.go
+++ b/internal/store/reference.go
@@ -61,6 +61,24 @@ func MoveRef(src, dst string, ref *model.Reference, body string) error {
 	return os.Remove(src)
 }
 
+// ArchiveReference moves an active reference to archive/reference/<tool>/.
+// References have no `status` field; archival is location-only. The caller is
+// responsible for rewriting the active INDEX.md afterwards.
+func ArchiveReference(cfg *config.Config, tool string, ref *model.Reference, body string) error {
+	src := PathForReferenceActive(cfg, tool, ref.ID)
+	dst := PathForReferenceArchive(cfg, tool, ref.ID)
+	return MoveRef(src, dst, ref, body)
+}
+
+// RestoreReference moves an archived reference back to reference/<tool>/.
+// Symmetric inverse of ArchiveReference. The caller is responsible for
+// rewriting the active INDEX.md afterwards.
+func RestoreReference(cfg *config.Config, tool string, ref *model.Reference, body string) error {
+	src := PathForReferenceArchive(cfg, tool, ref.ID)
+	dst := PathForReferenceActive(cfg, tool, ref.ID)
+	return MoveRef(src, dst, ref, body)
+}
+
 // PathForReferenceActive returns the canonical active path for a reference
 // owned by tool.
 func PathForReferenceActive(cfg *config.Config, tool, id string) string {

--- a/internal/store/reference_test.go
+++ b/internal/store/reference_test.go
@@ -303,6 +303,54 @@ func TestListReferenceToolsDiscoversSubdirs(t *testing.T) {
 	}
 }
 
+func TestArchiveAndRestoreReference(t *testing.T) {
+	cfg := newTestCfg(t)
+	if err := store.EnsureDirs(cfg); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 4, 17, 9, 0, 0, 0, time.UTC)
+	ref := makeRef("a1", "T", now)
+	active := store.PathForReferenceActive(cfg, "claude", ref.ID)
+	if err := store.WriteRef(active, ref, "body"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.ArchiveReference(cfg, "claude", ref, "body"); err != nil {
+		t.Fatalf("ArchiveReference: %v", err)
+	}
+	if _, err := os.Stat(active); !os.IsNotExist(err) {
+		t.Error("active path still exists after archive")
+	}
+	archived := store.PathForReferenceArchive(cfg, "claude", ref.ID)
+	if _, err := os.Stat(archived); err != nil {
+		t.Errorf("archive path missing after archive: %v", err)
+	}
+	got, err := store.FindReference(cfg, ref.ID)
+	if err != nil {
+		t.Fatalf("FindReference after archive: %v", err)
+	}
+	if !got.Archived {
+		t.Error("expected Archived=true after archive")
+	}
+
+	if err := store.RestoreReference(cfg, "claude", ref, "body"); err != nil {
+		t.Fatalf("RestoreReference: %v", err)
+	}
+	if _, err := os.Stat(archived); !os.IsNotExist(err) {
+		t.Error("archive path still exists after restore")
+	}
+	if _, err := os.Stat(active); err != nil {
+		t.Errorf("active path missing after restore: %v", err)
+	}
+	got, err = store.FindReference(cfg, ref.ID)
+	if err != nil {
+		t.Fatalf("FindReference after restore: %v", err)
+	}
+	if got.Archived {
+		t.Error("expected Archived=false after restore")
+	}
+}
+
 func TestMoveRef(t *testing.T) {
 	cfg := newTestCfg(t)
 	if err := store.EnsureDirs(cfg); err != nil {


### PR DESCRIPTION
## Summary

- Add `htd reference archive ID` and `htd reference restore ID` — symmetric inverses that move references between `reference/<tool>/<id>.md` and `archive/reference/<tool>/<id>.md`. Archival is location-only (references have no `status` field); both verbs refuse the wrong starting state, so neither can land silently.
- Add `--archived` flag to `htd reference list`, scoping the scan to the archive. Default listing remains active-only. Text rows carry an `(archived)` prefix; JSON rows carry `archived: true`.
- `htd reference get ID` already falls back to the archive (from PR #38). This PR pins the marker contract: `(archived)` line preceding the metadata block in text mode; `archived: true` in JSON, omitted on active hits.
- INDEX.md stays active-only — archive removes the entry, restore puts it back. The empty-state stub keeps the file diff-clean when the last active reference for a tool is archived.

## Design notes

- No standalone `htd reference index` noun-verb. `list` covers "show me what's there"; `list --archived` covers the archive view.
- `update` on an archived reference still works (location-only archival shouldn't lock fields), but does not regenerate INDEX.md since the entry is not in it.

## Test plan

- [x] `mise run lint`
- [x] `mise run test` (added 12 tests in `internal/store/reference_test.go` and `internal/command/reference_command_test.go`)
- [x] Manual smoke test: add → archive (INDEX.md falls to stub) → list / list --archived → get (archived marker in text and JSON) → restore (INDEX.md repopulates)

Closes #35