### PR TITLE
feat(reference): add area_of_focus canonical type

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -835,7 +835,7 @@ htd item restore ID
 
 The `reference` command group manages tool-scoped reference notes — durable, AI-readable context stored under `reference/<tool>/` (see `docs/datamodel.md §3`). Notes are grouped per tool so multi-assistant repos do not collide; the `--tool` flag selects the namespace and defaults to `claude`.
 
-Each tool directory has an auto-generated `INDEX.md` that lists every active reference grouped by `type:*` tag (`## user`, `## feedback`, `## project`, `## reference`, with a trailing `## other` for entries that carry no canonical type tag). The index is rewritten on every mutation; see §8.5 for the exact format and the repair verb.
+Each tool directory has an auto-generated `INDEX.md` that lists every active reference grouped by `type:*` tag (`## user`, `## feedback`, `## area_of_focus`, `## project`, `## reference`, with a trailing `## other` for entries that carry no canonical type tag). The index is rewritten on every mutation; see §8.5 for the exact format and the repair verb.
 
 ### 8.1 `htd reference add`
 
@@ -849,7 +849,7 @@ htd reference add --title TEXT [--body TEXT] [--tag TAG]... [--tool TOOL]
 |--------|----------|-------------|
 | `--title` | yes | Short description |
 | `--body` | no | Body content (Markdown) |
-| `--tag` | no | Tag (repeatable). Use `type:user`, `type:feedback`, `type:project`, or `type:reference` to drive `INDEX.md` grouping; other tags appear in `## other`. |
+| `--tag` | no | Tag (repeatable). Use `type:user`, `type:feedback`, `type:area_of_focus`, `type:project`, or `type:reference` to drive `INDEX.md` grouping; other tags appear in `## other`. |
 | `--tool` | no | Tool namespace (default `claude`). Determines `reference/<tool>/`. |
 
 **Behavior:**
@@ -986,7 +986,7 @@ htd reference restore ID
 The format is fully deterministic — the same set of references produces a byte-for-byte identical file:
 
 - An H1 line: `# Reference index`.
-- One section per non-empty `type:*` group, in fixed order: `## user`, `## feedback`, `## project`, `## reference`. Entries whose canonical type tag is missing or unrecognized (e.g. `type:area_of_focus`) land in a trailing `## other` section.
+- One section per non-empty `type:*` group, in fixed order: `## user`, `## feedback`, `## area_of_focus`, `## project`, `## reference`. Entries whose canonical type tag is missing or unrecognized (e.g. `type:misc`) land in a trailing `## other` section.
 - Within each section, entries sort by `updated_at` descending, with `id` ascending as the tiebreaker.
 - Each entry is one bullet line: `- [title](id.md) — short description`. The "short description" is the first non-blank line of the body with leading `#` stripped, truncated to 80 runes. The em-dash and description are omitted when no usable description line exists.
 - When no references are present, the body is the empty-state stub `_No entries._` (the file is still written rather than deleted, so archive-then-empty stays diff-clean).

--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -148,16 +148,17 @@ Active references live under `reference/<tool>/` so multi-assistant repositories
 
 ### 3.3 Type Tag Convention
 
-References are categorized by an optional `type:*` tag in the `tags` list. Four canonical values drive INDEX.md grouping:
+References are categorized by an optional `type:*` tag in the `tags` list. Five canonical values drive INDEX.md grouping:
 
 | Tag | Meaning |
 |-----|---------|
 | `type:user` | Information about the user — role, preferences, knowledge |
 | `type:feedback` | Guidance the user has given about how to approach work |
+| `type:area_of_focus` | An area of standing attention without a defined outcome — ongoing responsibility, role, or domain. Promote to `type:project` when a deliverable and deadline appear. |
 | `type:project` | Project-level context not derivable from code or git |
-| `type:reference` | Pointers to external systems (dashboards, trackers, dashboards) |
+| `type:reference` | Pointers to external systems (dashboards, trackers, doc URLs) |
 
-Other `type:*` values (e.g. `type:area_of_focus`) are valid; they fall into the `## other` INDEX section. References with no `type:*` tag also land in `## other`.
+Other `type:*` values (e.g. `type:misc`) are valid; they fall into the `## other` INDEX section. References with no `type:*` tag also land in `## other`.
 
 ### 3.4 Auto-Generated INDEX.md
 

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -20,7 +20,7 @@ const IndexEmptyMarker = "_No entries._"
 // Anything not in this list (including unrecognized type:* values and
 // references with no type:* tag at all) falls into the trailing "other"
 // section.
-var indexCanonicalTypes = []string{"user", "feedback", "project", "reference"}
+var indexCanonicalTypes = []string{"user", "feedback", "area_of_focus", "project", "reference"}
 
 // indexOtherSection is the header for entries that do not belong to any of
 // the canonical type sections.

--- a/internal/store/index_test.go
+++ b/internal/store/index_test.go
@@ -54,10 +54,11 @@ func TestRenderIndexGroupingAndSort(t *testing.T) {
 		refWithBody("u_old", "User old", "user old fact", t0, "type:user"),
 		refWithBody("u_new", "User new", "user new fact", t0.Add(2*time.Hour), "type:user"),
 		refWithBody("f1", "Feedback one", "feedback fact", t0.Add(time.Hour), "type:feedback"),
+		refWithBody("a1", "Area one", "area fact", t0, "type:area_of_focus"),
 		refWithBody("p1", "Project one", "project fact", t0, "type:project"),
 		refWithBody("r1", "Reference one", "reference fact", t0, "type:reference"),
 		refWithBody("o1", "Other one", "other fact", t0, "misc"),
-		refWithBody("o2", "Other two", "other2 fact", t0, "type:area_of_focus"),
+		refWithBody("o2", "Other two", "other2 fact", t0, "type:misc"),
 	}
 	got := string(store.RenderIndex(refs))
 
@@ -68,6 +69,8 @@ func TestRenderIndexGroupingAndSort(t *testing.T) {
 		"User old",
 		"## feedback",
 		"Feedback one",
+		"## area_of_focus",
+		"Area one",
 		"## project",
 		"Project one",
 		"## reference",
@@ -152,13 +155,13 @@ func TestRenderIndexTruncatesLongDesc(t *testing.T) {
 func TestRenderIndexUnknownTypeFallsToOther(t *testing.T) {
 	t0 := time.Date(2026, 4, 17, 9, 0, 0, 0, time.UTC)
 	refs := []store.ReferenceWithBody{
-		refWithBody("a", "A", "fact", t0, "type:area_of_focus"),
+		refWithBody("a", "A", "fact", t0, "type:misc"),
 	}
 	got := string(store.RenderIndex(refs))
 	if !strings.Contains(got, "## other") {
 		t.Errorf("expected `## other` section:\n%s", got)
 	}
-	for _, section := range []string{"## user", "## feedback", "## project", "## reference"} {
+	for _, section := range []string{"## user", "## feedback", "## area_of_focus", "## project", "## reference"} {
 		if strings.Contains(got, section) {
 			t.Errorf("did not expect section %q in single-other output:\n%s", section, got)
 		}

--- a/plugins/htd/.claude-plugin/plugin.json
+++ b/plugins/htd/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "htd",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Drive the htd five-phase workflow from Claude Code: capture, clarify, organize, reflect, engage. Also manages tool-scoped reference notes for durable AI context and a time-stamped journal lane for daily notes, weekly retros, and observation logs.",
   "author": {
     "name": "Naoto Takai",

--- a/plugins/htd/commands/reference.md
+++ b/plugins/htd/commands/reference.md
@@ -12,7 +12,7 @@ You are managing **References** — durable, AI-readable notes stored under `ref
 
 The user's arguments `$ARGUMENTS` are the title for a new reference. Quickly clarify with the user (in one short turn) two things you cannot infer from the title alone:
 
-1. **Type tag** — pick one of `type:user`, `type:feedback`, `type:project`, `type:reference`, or "other" (skip the type tag entirely). Suggest a reasonable default based on the title and confirm.
+1. **Type tag** — pick one of `type:user`, `type:feedback`, `type:area_of_focus`, `type:project`, `type:reference`, or "other" (skip the type tag entirely). Suggest a reasonable default based on the title and confirm.
 2. **Body** — at minimum the one-line fact (used as the INDEX.md description). Optionally a `## How to apply` section. If the user only gave you a title and you can paraphrase a clear fact line, propose it; otherwise ask.
 
 Then run:
@@ -27,7 +27,7 @@ Print the resulting ID. Do not chain into anything else.
 
 Ask the user what they want to do:
 
-- **Save a new reference** → ask for title (required), type tag (one of the four canonical, or skip), and body (fact line + optional "How to apply"). Then run `htd reference add ...` as above.
+- **Save a new reference** → ask for title (required), type tag (one of the five canonical, or skip), and body (fact line + optional "How to apply"). Then run `htd reference add ...` as above.
 - **Look up an existing one** → run `htd reference list --json` and surface IDs/titles. If the user names one, run `htd reference get <id>`.
 - **Archive a stale fact** → confirm the ID, then `htd reference archive <id>`.
 - **Restore something** → confirm the ID, then `htd reference restore <id>`.
@@ -40,9 +40,10 @@ Pick the path the user describes; don't run a menu unless they're unsure.
 |-----|-------------|
 | `type:user` | Anything about the user themselves — role, preferences, knowledge level, working style. |
 | `type:feedback` | Corrections or validations the user has given about how to work. Capture *why* alongside the rule. |
+| `type:area_of_focus` | An area of standing attention without a defined outcome — an ongoing responsibility, role, or domain. Re-tag as `type:project` once a deliverable and deadline appear. |
 | `type:project` | Non-derivable context on a project — motivations, deadlines, stakeholder asks. |
 | `type:reference` | Pointers to external sources of truth (dashboards, trackers, doc URLs). |
-| (no tag) | Falls into `## other` in INDEX.md. Use only when none of the four fit. |
+| (no tag) | Falls into `## other` in INDEX.md. Use only when none of the five fit. |
 
 ## Notes
 

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: htd-workflow
 description: Use when the user wants help managing tasks with htd, storing durable AI context, or keeping a journal/retro — any mention of htd, inbox, next actions, projects, waiting-for, someday, tickler, capture, clarify, organize, reflect, engage, reference, journal, retro, daily note, "remember this fact / project context / preference", or "let's do a retro". Teaches the five-phase workflow, the reference (tool-scoped memory) surface, the journal lane, and how to pick the right CLI command.
-version: 0.3.0
+version: 0.3.1
 ---
 
 # htd workflow
@@ -39,12 +39,13 @@ A Reference is **non-actionable, durable** information stored for future retriev
 
 - User profile (`type:user`) — role, preferences, knowledge.
 - Feedback patterns (`type:feedback`) — corrections and validations the user has given about how to work.
+- Areas of focus (`type:area_of_focus`) — standing attention without a defined outcome (e.g. an ongoing responsibility or role). Promote to `type:project` when a deliverable and deadline appear.
 - Project context (`type:project`) — non-derivable background on ongoing work.
 - External pointers (`type:reference`) — dashboards, trackers, source-of-truth links.
 
 Storage layout is `reference/<tool>/<id>.md` — `<tool>` namespaces references per AI assistant so multi-assistant repos don't collide. The `--tool` flag selects the namespace and defaults to `claude`.
 
-Each tool directory carries an auto-generated `INDEX.md` that lists every active reference grouped by `type:*` tag (`## user`, `## feedback`, `## project`, `## reference`, trailing `## other` for anything else). The index is rewritten on every mutation; AI sessions can load it cheaply at startup. Do not edit `INDEX.md` by hand — run `htd reference reindex` to repair if it ever drifts (e.g., merge conflict).
+Each tool directory carries an auto-generated `INDEX.md` that lists every active reference grouped by `type:*` tag (`## user`, `## feedback`, `## area_of_focus`, `## project`, `## reference`, trailing `## other` for anything else). The index is rewritten on every mutation; AI sessions can load it cheaply at startup. Do not edit `INDEX.md` by hand — run `htd reference reindex` to repair if it ever drifts (e.g., merge conflict).
 
 The body convention is **fact line first** (used as the INDEX description, truncated to 80 runes) optionally followed by a `## How to apply` section. The convention isn't enforced; just follow it.
 
@@ -129,7 +130,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 - `htd item restore ID` — undo an accidental `engage done`/`cancel`/`discard`/`archive`; brings a terminal item back to `active` and moves it to `items/<kind>/`.
 
 **Reference (tool-scoped durable notes)** — see "References" above for the data type. All reference verbs accept `--tool TOOL` and default to `claude`.
-- `htd reference add --title TEXT [--body TEXT] [--tag TAG]... [--tool TOOL]` — tag with `type:user|feedback|project|reference` to drive INDEX.md grouping; other tags fall into `## other`.
+- `htd reference add --title TEXT [--body TEXT] [--tag TAG]... [--tool TOOL]` — tag with `type:user|feedback|area_of_focus|project|reference` to drive INDEX.md grouping; other tags fall into `## other`.
 - `htd reference get ID` — falls back to the archive automatically. Archived hits are marked `(archived)` in text mode and `archived: true` in JSON.
 - `htd reference list [--tool TOOL] [--tag TAG] [--archived]` — default lists the active set; `--archived` flips to the archive view (mutually exclusive).
 - `htd reference update ID FIELD=VALUE...` — supported fields: `title`, `body`, `tags`. Protected: `id`, `created_at`, `tool`.
@@ -159,6 +160,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 | Completing a task | `htd engage done ID` (direct call is fine) |
 | "I marked the wrong item done", undo an accidental terminal transition | `htd item restore ID` |
 | "remember that I prefer X", "save this as a fact", "for future sessions you should know Y" | `/htd:reference` or `htd reference add --title "..." --tag type:user --body "..."` |
+| "I'm taking on X as an ongoing responsibility", "I'm now stewarding Y but no concrete deliverable yet" | `htd reference add --title "..." --tag type:area_of_focus --body "..."` (promote to `type:project` once a deliverable + deadline appear) |
 | "what do you know about my project", "load my context", session-start orientation | Read `reference/<tool>/INDEX.md` directly, then `htd reference get <id>` for entries you need |
 | "this fact is stale" / "we don't do X anymore" | `htd reference archive ID` (use `restore` if you regret it) |
 | "the index looks wrong" / merge conflict in `INDEX.md` | `htd reference reindex` |


### PR DESCRIPTION
## Summary

Add `type:area_of_focus` as a fifth canonical reference type per #37, lifting it out of the `## other` bucket and giving it its own section in `INDEX.md`.

Section order, top-down: `user → feedback → area_of_focus → project → reference → other`. Reads as: who you are → how to work with you → what you steward long-term → what's in flight → where to look things up. Areas of focus are broader-strokes than projects (standing responsibilities without a defined outcome); promote to `type:project` when a deliverable and deadline appear.

## Changes

- **htd CLI** — append to `indexCanonicalTypes` at the right position; tests updated; docs (`cli.md §8`, `datamodel.md §3.3`) reflect the fifth canonical type.
- **Plugin** — bump to 0.3.1; SKILL.md References section, cheat sheet, and Choosing-a-command pick up `area_of_focus`; `/htd:reference` command type-tag guide gains a row with the area→project promotion note.

## Smoke test

```
$ htd reference add --title "Q3 IT audit ownership" --tag type:area_of_focus --body "Standing responsibility ..."
$ cat reference/claude/INDEX.md
# Reference index

## user
- [Prefer concise replies](...) — User wants concise responses.

## area_of_focus
- [Q3 IT audit ownership](...) — Standing responsibility ...

## project
- [Launch CLI v1](...) — Ship by 2026-06-30.
```

## Test plan

- [x] `mise run lint`
- [x] `mise run test` (existing INDEX.md tests cover the new section ordering)
- [x] Plugin validator: PASS
- [x] Manual smoke test: section appears in correct position; unknown `type:misc` still routes to `## other`

## Out of scope

Re-typing existing `type:project` files to `type:area_of_focus` is a user decision; this PR adds the option, not a migration.

Closes #37