### PR TITLE
fix(output): prevent duplicate error output

### DIFF
--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -276,6 +276,20 @@ func TestClarifyShowNotFound(t *testing.T) {
 	}
 }
 
+// Cobra must not print the error itself; the package-level Execute() owns
+// stderr formatting. Otherwise users see the same message twice (once with
+// "Error:" from cobra and once with "error:" from Execute).
+func TestRootSilencesCobraErrorOutput(t *testing.T) {
+	dir := setupDir(t)
+	_, errOut, err := runCmd(t, dir, "item", "get", "list")
+	if !store.IsNotFound(err) {
+		t.Fatalf("expected NotFoundError, got %v", err)
+	}
+	if errOut != "" {
+		t.Errorf("cobra should not print errors; got stderr=%q", errOut)
+	}
+}
+
 func TestClarifyUpdate(t *testing.T) {
 	dir := setupDir(t)
 	item := nowItem("20260417-update_me", model.KindInbox, model.StatusActive)

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -26,9 +26,10 @@ func NewRootCommand() *cobra.Command {
 	)
 
 	root := &cobra.Command{
-		Use:          "htd",
-		Short:        "Headless task management",
-		SilenceUsage: true,
+		Use:           "htd",
+		Short:         "Headless task management",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	root.PersistentFlags().BoolVar(&jsonMode, "json", false, "Output in JSON format")
@@ -80,8 +81,8 @@ func Execute() {
 	root.SetErr(os.Stderr)
 
 	if err := root.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
 		if store.IsNotFound(err) {
-			fmt.Fprintln(os.Stderr, "error:", err)
 			os.Exit(output.ExitNotFound)
 		}
 		os.Exit(output.ExitError)


### PR DESCRIPTION
Closes #43.

## Summary

`htd item get list` (and any other not-found error) printed the same message twice:

```
$ htd item get list
Error: item "list" not found
error: item "list" not found
```

Cobra's default error printer wrote `Error:` and `command.Execute()` then wrote `error:` for the not-found branch. Other error paths only emitted cobra's `Error:` line, so the prefix was also inconsistent across error types.

## Fix

- Set `SilenceErrors: true` on the root command so cobra never prints errors itself.
- Always print errors via `command.Execute()` with the lowercase `error:` prefix.
- Exit codes are unchanged: `2` for not-found, `1` for everything else.

A regression test (`TestRootSilencesCobraErrorOutput`) asserts that cobra leaves stderr empty when a not-found error bubbles up through `runCmd`.

## Other places checked

- `internal/output.PrintError` exists but is only called from its own test, so no callers double-print.
- No other `os.Exit` / `Fprintln(os.Stderr, ...)` paths exist outside `command/root.go`.

## Test plan

- [x] `mise run test` — all green
- [x] `mise run lint` — clean
- [x] Manual repro: `htd item get list` prints exactly one `error:` line, exits 2
- [x] Manual repro: `htd capture add` (missing `--title`) prints one `error:` line, exits 1