### PR TITLE
feat(reflect): add project subcommand

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -507,6 +507,63 @@ $ htd reflect tickler --pull
 20260417-quarterly_review_prep
 ```
 
+### 5.7 `htd reflect project`
+
+Show a project's metadata together with its active and recently-archived children, in one call.
+
+```
+htd reflect project ID [--since DATE]
+```
+
+| Argument / Option | Required | Description |
+|-------------------|----------|-------------|
+| `ID` | yes | The project's item ID |
+| `--since` | no | Cutoff for the archived-children section (`YYYY-MM-DD`). Default: 30 days ago. Pass `--since ""` to show every archived child. |
+
+**Behavior:**
+
+1. Look up the item by `ID`. Exit with code `2` if the item is not found, or if the resolved item's `kind` is not `project`.
+2. Display project metadata and body using the same fields as `clarify show` / `item get`.
+3. List active children linked to the project (`project: ID` in front matter), grouped into three sections:
+   - **next actions** — `kind: next_action`, sorted by `updated_at` descending. Columns: `ID`, `TITLE`, `TAGS`, `UPDATED_AT`.
+   - **waiting for** — `kind: waiting_for`, sorted by `created_at` ascending (oldest first, mirroring `reflect waiting`). Columns: `ID`, `TITLE`, `CREATED_AT`.
+   - **ticklers** — `kind: tickler`, sorted by `defer_until` ascending (earliest fire first; nil last). Columns: `ID`, `TITLE`, `DEFER_UNTIL`.
+4. List recently archived children — items linked to the project whose `status` is terminal (`done`, `canceled`, `discarded`, or `archived`) and whose `updated_at` is on or after the cutoff. Sorted by `updated_at` descending. Columns: `ID`, `KIND`, `STATUS`, `UPDATED_AT`, `TITLE`.
+5. Sections with no children render the section header followed by `(none)`, so the structure stays predictable.
+
+**Constraints:**
+
+- `someday` children are not surfaced; per orthodox workflow, `someday` items rarely carry a project link.
+
+**JSON output:**
+
+A single object so it parses in one read:
+
+```json
+{
+  "project":      { "id": "...", "title": "...", "body": "...", ... },
+  "next_actions": [ { ... }, ... ],
+  "waiting_for":  [ ... ],
+  "ticklers":     [ ... ],
+  "archived":     [ ... ]
+}
+```
+
+The `project` entry includes the body; child entries omit it, matching the convention list views already use. Empty sections render as `[]`, never `null`.
+
+**Examples:**
+
+```
+# Default 30-day archive window
+$ htd reflect project 20260420-launch_cli
+
+# Full archive history
+$ htd reflect project 20260420-launch_cli --since ""
+
+# Custom window
+$ htd reflect project 20260420-launch_cli --since 2026-04-01
+```
+
 ---
 
 ## 6. Engage
@@ -1208,6 +1265,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd reflect review` | List items due for review |
 | `htd reflect log --since DATE` | List recently resolved items (activity log) |
 | `htd reflect tickler [--pull]` | List fired tickler items, or pull them into the inbox |
+| `htd reflect project ID` | Show a project with its active and recently-archived children |
 | `htd engage done ID [ID...]` | Mark one or more items as done |
 | `htd engage cancel ID [ID...]` | Cancel one or more active items |
 | `htd engage next-actions` | List next actions ready to work on now |

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1292,6 +1292,297 @@ func TestReflectProjectsStalled(t *testing.T) {
 	}
 }
 
+func TestReflectProject(t *testing.T) {
+	dir := setupDir(t)
+	proj := nowItem("20260501-proj", model.KindProject, model.StatusActive)
+	writeItem(t, dir, proj, "")
+
+	na := nowItem("20260501-na", model.KindNextAction, model.StatusActive)
+	na.Project = "20260501-proj"
+	writeItem(t, dir, na, "")
+
+	wf := nowItem("20260501-wf", model.KindWaitingFor, model.StatusActive)
+	wf.Project = "20260501-proj"
+	writeItem(t, dir, wf, "")
+
+	defer1 := time.Now().AddDate(0, 0, 7)
+	tk := nowItem("20260501-tk", model.KindTickler, model.StatusActive)
+	tk.Project = "20260501-proj"
+	tk.DeferUntil = &defer1
+	writeItem(t, dir, tk, "")
+
+	arch := nowItem("20260501-arch", model.KindNextAction, model.StatusDone)
+	arch.Project = "20260501-proj"
+	writeItem(t, dir, arch, "")
+
+	// Sibling with no project link must not leak in.
+	stray := nowItem("20260501-stray", model.KindNextAction, model.StatusActive)
+	writeItem(t, dir, stray, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "project", "20260501-proj")
+	if err != nil {
+		t.Fatalf("reflect project: %v", err)
+	}
+
+	for _, want := range []string{
+		"id:         20260501-proj",
+		"20260501-na", "20260501-wf", "20260501-tk", "20260501-arch",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "20260501-stray") {
+		t.Errorf("unrelated item leaked into output:\n%s", out)
+	}
+}
+
+func TestReflectProjectSections(t *testing.T) {
+	dir := setupDir(t)
+	proj := nowItem("20260501-proj", model.KindProject, model.StatusActive)
+	writeItem(t, dir, proj, "")
+
+	na := nowItem("20260501-na", model.KindNextAction, model.StatusActive)
+	na.Project = "20260501-proj"
+	writeItem(t, dir, na, "")
+	wf := nowItem("20260501-wf", model.KindWaitingFor, model.StatusActive)
+	wf.Project = "20260501-proj"
+	writeItem(t, dir, wf, "")
+	deferAt := time.Now().AddDate(0, 0, 7)
+	tk := nowItem("20260501-tk", model.KindTickler, model.StatusActive)
+	tk.Project = "20260501-proj"
+	tk.DeferUntil = &deferAt
+	writeItem(t, dir, tk, "")
+	arch := nowItem("20260501-arch", model.KindNextAction, model.StatusDone)
+	arch.Project = "20260501-proj"
+	writeItem(t, dir, arch, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "project", "20260501-proj")
+	if err != nil {
+		t.Fatalf("reflect project: %v", err)
+	}
+
+	naIdx := strings.Index(out, "next actions:")
+	wfIdx := strings.Index(out, "waiting for:")
+	tkIdx := strings.Index(out, "ticklers:")
+	archIdx := strings.Index(out, "recently archived")
+	if naIdx < 0 || wfIdx < 0 || tkIdx < 0 || archIdx < 0 {
+		t.Fatalf("missing section header(s): naIdx=%d wfIdx=%d tkIdx=%d archIdx=%d\n%s",
+			naIdx, wfIdx, tkIdx, archIdx, out)
+	}
+	if naIdx >= wfIdx || wfIdx >= tkIdx || tkIdx >= archIdx {
+		t.Fatalf("section ordering wrong:\n%s", out)
+	}
+
+	naSec := out[naIdx:wfIdx]
+	wfSec := out[wfIdx:tkIdx]
+	tkSec := out[tkIdx:archIdx]
+	archSec := out[archIdx:]
+
+	if !strings.Contains(naSec, "TAGS") || !strings.Contains(naSec, "UPDATED_AT") {
+		t.Errorf("next actions section missing TAGS/UPDATED_AT columns:\n%s", naSec)
+	}
+	if !strings.Contains(wfSec, "CREATED_AT") {
+		t.Errorf("waiting for section missing CREATED_AT column:\n%s", wfSec)
+	}
+	if strings.Contains(wfSec, "STATUS") {
+		t.Errorf("waiting for section should not show STATUS column:\n%s", wfSec)
+	}
+	if !strings.Contains(tkSec, "DEFER_UNTIL") {
+		t.Errorf("ticklers section missing DEFER_UNTIL column:\n%s", tkSec)
+	}
+	if !strings.Contains(archSec, "KIND") || !strings.Contains(archSec, "STATUS") {
+		t.Errorf("archive section missing KIND/STATUS columns:\n%s", archSec)
+	}
+}
+
+func TestReflectProjectEmptySections(t *testing.T) {
+	dir := setupDir(t)
+	proj := nowItem("20260501-proj", model.KindProject, model.StatusActive)
+	writeItem(t, dir, proj, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "project", "20260501-proj")
+	if err != nil {
+		t.Fatalf("reflect project: %v", err)
+	}
+	for _, want := range []string{"next actions:", "waiting for:", "ticklers:", "recently archived"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing section header %q in output:\n%s", want, out)
+		}
+	}
+	if strings.Count(out, "(none)") != 4 {
+		t.Errorf("expected 4 (none) markers for empty sections, got %d:\n%s",
+			strings.Count(out, "(none)"), out)
+	}
+}
+
+func TestReflectProjectNotFound(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "reflect", "project", "does-not-exist")
+	if err == nil {
+		t.Fatalf("expected NotFound error, got nil")
+	}
+	if !store.IsNotFound(err) {
+		t.Errorf("expected store.NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestReflectProjectRejectsNonProject(t *testing.T) {
+	dir := setupDir(t)
+	na := nowItem("20260501-na", model.KindNextAction, model.StatusActive)
+	writeItem(t, dir, na, "")
+
+	_, _, err := runCmd(t, dir, "reflect", "project", "20260501-na")
+	if err == nil {
+		t.Fatalf("expected NotFound error for non-project ID, got nil")
+	}
+	if !store.IsNotFound(err) {
+		t.Errorf("expected store.NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestReflectProjectArchivedSinceWindow(t *testing.T) {
+	dir := setupDir(t)
+	proj := nowItem("20260501-proj", model.KindProject, model.StatusActive)
+	writeItem(t, dir, proj, "")
+
+	recent := nowItem("20260501-recent_done", model.KindNextAction, model.StatusDone)
+	recent.Project = "20260501-proj"
+	recent.UpdatedAt = time.Now().AddDate(0, 0, -5)
+	writeItem(t, dir, recent, "")
+
+	old := nowItem("20260101-old_done", model.KindNextAction, model.StatusDone)
+	old.Project = "20260501-proj"
+	old.UpdatedAt = time.Now().AddDate(0, 0, -60)
+	writeItem(t, dir, old, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "project", "20260501-proj")
+	if err != nil {
+		t.Fatalf("reflect project: %v", err)
+	}
+	if !strings.Contains(out, "20260501-recent_done") {
+		t.Errorf("default cutoff should include 5-day-old item:\n%s", out)
+	}
+	if strings.Contains(out, "20260101-old_done") {
+		t.Errorf("default 30-day cutoff should hide 60-day-old item:\n%s", out)
+	}
+
+	out, _, err = runCmd(t, dir, "reflect", "project", "20260501-proj", "--since", "")
+	if err != nil {
+		t.Fatalf("reflect project --since '': %v", err)
+	}
+	if !strings.Contains(out, "20260501-recent_done") {
+		t.Errorf("--since '' should still show recent:\n%s", out)
+	}
+	if !strings.Contains(out, "20260101-old_done") {
+		t.Errorf("--since '' should show old:\n%s", out)
+	}
+
+	out, _, err = runCmd(t, dir, "reflect", "project", "20260501-proj",
+		"--since", time.Now().AddDate(0, 0, -10).Format("2006-01-02"))
+	if err != nil {
+		t.Fatalf("reflect project --since: %v", err)
+	}
+	if !strings.Contains(out, "20260501-recent_done") {
+		t.Errorf("--since 10 days ago should include 5-day-old item:\n%s", out)
+	}
+	if strings.Contains(out, "20260101-old_done") {
+		t.Errorf("--since 10 days ago should hide 60-day-old item:\n%s", out)
+	}
+}
+
+func TestReflectProjectInvalidSince(t *testing.T) {
+	dir := setupDir(t)
+	proj := nowItem("20260501-proj", model.KindProject, model.StatusActive)
+	writeItem(t, dir, proj, "")
+
+	_, _, err := runCmd(t, dir, "reflect", "project", "20260501-proj", "--since", "not-a-date")
+	if err == nil {
+		t.Fatalf("expected error for malformed --since")
+	}
+}
+
+func TestReflectProjectArchivedAllTerminalStatuses(t *testing.T) {
+	dir := setupDir(t)
+	proj := nowItem("20260501-proj", model.KindProject, model.StatusActive)
+	writeItem(t, dir, proj, "")
+
+	for _, st := range []model.Status{model.StatusDone, model.StatusCanceled, model.StatusArchived} {
+		it := nowItem("20260501-arch_"+string(st), model.KindNextAction, st)
+		it.Project = "20260501-proj"
+		writeItem(t, dir, it, "")
+	}
+
+	out, _, err := runCmd(t, dir, "reflect", "project", "20260501-proj")
+	if err != nil {
+		t.Fatalf("reflect project: %v", err)
+	}
+	for _, st := range []model.Status{model.StatusDone, model.StatusCanceled, model.StatusArchived} {
+		want := "20260501-arch_" + string(st)
+		if !strings.Contains(out, want) {
+			t.Errorf("archive section should include %s items: missing %q\n%s", st, want, out)
+		}
+	}
+}
+
+func TestReflectProjectJSON(t *testing.T) {
+	dir := setupDir(t)
+	proj := nowItem("20260501-proj", model.KindProject, model.StatusActive)
+	writeItem(t, dir, proj, "Project body content")
+
+	na := nowItem("20260501-na", model.KindNextAction, model.StatusActive)
+	na.Project = "20260501-proj"
+	writeItem(t, dir, na, "")
+
+	arch := nowItem("20260501-arch", model.KindNextAction, model.StatusDone)
+	arch.Project = "20260501-proj"
+	writeItem(t, dir, arch, "")
+
+	out, _, err := runCmd(t, dir, "--json", "reflect", "project", "20260501-proj")
+	if err != nil {
+		t.Fatalf("reflect project --json: %v", err)
+	}
+
+	var v struct {
+		Project     map[string]any   `json:"project"`
+		NextActions []map[string]any `json:"next_actions"`
+		WaitingFor  []map[string]any `json:"waiting_for"`
+		Ticklers    []map[string]any `json:"ticklers"`
+		Archived    []map[string]any `json:"archived"`
+	}
+	if err := json.Unmarshal([]byte(out), &v); err != nil {
+		t.Fatalf("parse json: %v\n%s", err, out)
+	}
+
+	if v.Project["id"] != "20260501-proj" {
+		t.Errorf("project.id: %v", v.Project["id"])
+	}
+	if v.Project["body"] != "Project body content" {
+		t.Errorf("project.body: %v", v.Project["body"])
+	}
+	if len(v.NextActions) != 1 || v.NextActions[0]["id"] != "20260501-na" {
+		t.Errorf("next_actions: %v", v.NextActions)
+	}
+	if _, has := v.NextActions[0]["body"]; has {
+		t.Errorf("list entry should omit body: %v", v.NextActions[0])
+	}
+	if len(v.Archived) != 1 || v.Archived[0]["id"] != "20260501-arch" {
+		t.Errorf("archived: %v", v.Archived)
+	}
+	if v.WaitingFor == nil {
+		t.Errorf("waiting_for should be an empty array, not absent")
+	}
+	if v.Ticklers == nil {
+		t.Errorf("ticklers should be an empty array, not absent")
+	}
+	if len(v.WaitingFor) != 0 {
+		t.Errorf("waiting_for: want empty, got %v", v.WaitingFor)
+	}
+	if len(v.Ticklers) != 0 {
+		t.Errorf("ticklers: want empty, got %v", v.Ticklers)
+	}
+}
+
 func TestReflectWaiting(t *testing.T) {
 	dir := setupDir(t)
 	writeItem(t, dir, nowItem("20260417-wait1", model.KindWaitingFor, model.StatusActive), "")

--- a/internal/command/reflect.go
+++ b/internal/command/reflect.go
@@ -19,12 +19,124 @@ func newReflectCommand(c *container) *cobra.Command {
 	cmd.AddCommand(
 		newReflectNextActionsCommand(c),
 		newReflectProjectsCommand(c),
+		newReflectProjectCommand(c),
 		newReflectWaitingCommand(c),
 		newReflectReviewCommand(c),
 		newReflectLogCommand(c),
 		newReflectTicklerCommand(c),
 	)
 	return cmd
+}
+
+func newReflectProjectCommand(c *container) *cobra.Command {
+	const archiveDefaultDays = 30
+	var since string
+
+	cmd := &cobra.Command{
+		Use:   "project ID",
+		Short: "Show a project with its active and recently-archived children",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectID := args[0]
+
+			path, err := store.FindItem(c.cfg, projectID)
+			if err != nil {
+				return err
+			}
+			project, body, err := store.Read(path)
+			if err != nil {
+				return err
+			}
+			if project.Kind != model.KindProject {
+				return &store.NotFoundError{Kind: store.EntityItem, ID: projectID}
+			}
+
+			cutoff, err := resolveProjectArchiveCutoff(cmd, since, archiveDefaultDays)
+			if err != nil {
+				return err
+			}
+
+			active := model.StatusActive
+			naKind := model.KindNextAction
+			wfKind := model.KindWaitingFor
+			tkKind := model.KindTickler
+
+			nextActions, err := store.List(c.cfg, store.Filter{Kind: &naKind, Status: &active, ProjectID: projectID})
+			if err != nil {
+				return err
+			}
+			sort.Slice(nextActions, func(i, j int) bool {
+				return nextActions[i].UpdatedAt.After(nextActions[j].UpdatedAt)
+			})
+
+			waitingFor, err := store.List(c.cfg, store.Filter{Kind: &wfKind, Status: &active, ProjectID: projectID})
+			if err != nil {
+				return err
+			}
+			sort.Slice(waitingFor, func(i, j int) bool {
+				return waitingFor[i].CreatedAt.Before(waitingFor[j].CreatedAt)
+			})
+
+			ticklers, err := store.List(c.cfg, store.Filter{Kind: &tkKind, Status: &active, ProjectID: projectID})
+			if err != nil {
+				return err
+			}
+			sort.Slice(ticklers, func(i, j int) bool {
+				if ticklers[i].DeferUntil == nil {
+					return false
+				}
+				if ticklers[j].DeferUntil == nil {
+					return true
+				}
+				return ticklers[i].DeferUntil.Before(*ticklers[j].DeferUntil)
+			})
+
+			linked, err := store.List(c.cfg, store.Filter{ProjectID: projectID})
+			if err != nil {
+				return err
+			}
+			var archived []*model.Item
+			for _, it := range linked {
+				if !model.IsTerminal(it.Status) {
+					continue
+				}
+				if !cutoff.IsZero() && it.UpdatedAt.Before(cutoff) {
+					continue
+				}
+				archived = append(archived, it)
+			}
+			sort.Slice(archived, func(i, j int) bool {
+				return archived[i].UpdatedAt.After(archived[j].UpdatedAt)
+			})
+
+			c.printer.PrintProjectView(project, body, nextActions, waitingFor, ticklers, archived, cutoff)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&since, "since", "",
+		"Show archived children updated on or after this date (YYYY-MM-DD); default is 30 days ago, pass --since '' to show all")
+	return cmd
+}
+
+// resolveProjectArchiveCutoff returns the cutoff time for the archive
+// section of `reflect project`. The flag's three-state behavior is:
+//   - flag absent → default cutoff (now minus defaultDays)
+//   - --since YYYY-MM-DD → cutoff at that date, local midnight
+//   - --since '' (explicitly empty) → zero time, meaning "no cutoff"
+func resolveProjectArchiveCutoff(cmd *cobra.Command, since string, defaultDays int) (time.Time, error) {
+	flag := cmd.Flags().Lookup("since")
+	if flag == nil || !flag.Changed {
+		return time.Now().AddDate(0, 0, -defaultDays), nil
+	}
+	if since == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.ParseInLocation("2006-01-02", since, time.Local)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("--since: cannot parse %q as date", since)
+	}
+	return t, nil
 }
 
 func newReflectNextActionsCommand(c *container) *cobra.Command {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -316,6 +316,167 @@ func (p *Printer) printItemsJSON(items []*model.Item) {
 	fmt.Fprintln(p.out, string(data))
 }
 
+// PrintProjectView prints `reflect project` output: project metadata + body
+// followed by per-section tables for active children (next actions, waiting
+// for, ticklers) and recently archived children. Each section uses columns
+// chosen for the load-bearing signal in this view (see docs/cli.md §5.7).
+//
+// archivedSince is the cutoff used for the archive section; the zero value
+// means "no cutoff" (rendered as "(all)" in the section header).
+//
+// JSON output is a single object: {project, next_actions, waiting_for,
+// ticklers, archived}. The project entry includes its body; child entries
+// omit body, matching the convention printItemsJSON already uses for lists.
+func (p *Printer) PrintProjectView(
+	project *model.Item, body string,
+	nextActions, waitingFor, ticklers, archived []*model.Item,
+	archivedSince time.Time,
+) {
+	if p.json {
+		p.printProjectViewJSON(project, body, nextActions, waitingFor, ticklers, archived)
+		return
+	}
+	p.printProjectViewText(project, body, nextActions, waitingFor, ticklers, archived, archivedSince)
+}
+
+func (p *Printer) printProjectViewText(
+	project *model.Item, body string,
+	nextActions, waitingFor, ticklers, archived []*model.Item,
+	archivedSince time.Time,
+) {
+	p.printItemText(project, body)
+	fmt.Fprintln(p.out)
+
+	fmt.Fprintln(p.out, "next actions:")
+	writeProjectNextActionRows(p.out, nextActions)
+	fmt.Fprintln(p.out)
+
+	fmt.Fprintln(p.out, "waiting for:")
+	writeProjectWaitingRows(p.out, waitingFor)
+	fmt.Fprintln(p.out)
+
+	fmt.Fprintln(p.out, "ticklers:")
+	writeProjectTicklerRows(p.out, ticklers)
+	fmt.Fprintln(p.out)
+
+	label := "recently archived"
+	if archivedSince.IsZero() {
+		label += " (all):"
+	} else {
+		label += " (since " + archivedSince.Format("2006-01-02") + "):"
+	}
+	fmt.Fprintln(p.out, label)
+	writeProjectArchiveRows(p.out, archived)
+}
+
+func writeProjectNextActionRows(w io.Writer, items []*model.Item) {
+	if len(items) == 0 {
+		fmt.Fprintln(w, "(none)")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tTITLE\tTAGS\tUPDATED_AT")
+	for _, it := range items {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			it.ID,
+			truncateRunes(it.Title, 40),
+			formatTagList(it.Tags),
+			it.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		)
+	}
+	_ = tw.Flush()
+}
+
+func writeProjectWaitingRows(w io.Writer, items []*model.Item) {
+	if len(items) == 0 {
+		fmt.Fprintln(w, "(none)")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tTITLE\tCREATED_AT")
+	for _, it := range items {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n",
+			it.ID,
+			truncateRunes(it.Title, 40),
+			it.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		)
+	}
+	_ = tw.Flush()
+}
+
+func writeProjectTicklerRows(w io.Writer, items []*model.Item) {
+	if len(items) == 0 {
+		fmt.Fprintln(w, "(none)")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tTITLE\tDEFER_UNTIL")
+	for _, it := range items {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n",
+			it.ID,
+			truncateRunes(it.Title, 40),
+			formatDueAt(it.DeferUntil),
+		)
+	}
+	_ = tw.Flush()
+}
+
+func writeProjectArchiveRows(w io.Writer, items []*model.Item) {
+	if len(items) == 0 {
+		fmt.Fprintln(w, "(none)")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tKIND\tSTATUS\tUPDATED_AT\tTITLE")
+	for _, it := range items {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			it.ID,
+			it.Kind,
+			it.Status,
+			it.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			truncateRunes(it.Title, 40),
+		)
+	}
+	_ = tw.Flush()
+}
+
+func formatTagList(tags []string) string {
+	if len(tags) == 0 {
+		return "-"
+	}
+	return strings.Join(tags, ",")
+}
+
+func (p *Printer) printProjectViewJSON(
+	project *model.Item, body string,
+	nextActions, waitingFor, ticklers, archived []*model.Item,
+) {
+	type projectViewJSON struct {
+		Project     itemJSON   `json:"project"`
+		NextActions []itemJSON `json:"next_actions"`
+		WaitingFor  []itemJSON `json:"waiting_for"`
+		Ticklers    []itemJSON `json:"ticklers"`
+		Archived    []itemJSON `json:"archived"`
+	}
+	v := projectViewJSON{
+		Project:     toItemJSON(project, body),
+		NextActions: toItemJSONList(nextActions),
+		WaitingFor:  toItemJSONList(waitingFor),
+		Ticklers:    toItemJSONList(ticklers),
+		Archived:    toItemJSONList(archived),
+	}
+	data, _ := json.Marshal(v)
+	fmt.Fprintln(p.out, string(data))
+}
+
+func toItemJSONList(items []*model.Item) []itemJSON {
+	arr := make([]itemJSON, len(items))
+	for i, it := range items {
+		arr[i] = toItemJSON(it, "")
+	}
+	return arr
+}
+
 // PrintLogItems prints a reflect log view: ID, KIND, STATUS, UPDATED_AT, TITLE.
 // JSON output is the same shape as PrintItems (full item fields).
 func (p *Printer) PrintLogItems(items []*model.Item) {


### PR DESCRIPTION
Closes #45.

## Summary

Adds `htd reflect project ID [--since DATE]` so weekly review and "what's the state of project X" introspection no longer require composing `reflect next-actions`, `engage waiting`, and `reflect log` with grep.

One call returns:

- the project's own metadata + body
- active children grouped into three sections (next actions, waiting for, ticklers)
- recently-archived children, with a 30-day default cutoff (override via `--since YYYY-MM-DD`; pass `--since ''` for the full archive)

`--json` returns a single object — `{ project, next_actions, waiting_for, ticklers, archived }` — drop-in for review scripts.

## Per-section columns

Reflects reviewer feedback in the issue thread — each section surfaces the load-bearing signal for its kind:

| Section | Columns |
|---|---|
| next actions | `ID, TITLE, TAGS, UPDATED_AT` |
| waiting for | `ID, TITLE, CREATED_AT` |
| ticklers | `ID, TITLE, DEFER_UNTIL` |
| archive | `ID, KIND, STATUS, UPDATED_AT, TITLE` |

`PROJECT` is dropped from each section because it's constant — the parent project's ID is in the metadata block above. Empty sections render as `(none)`.

## Decisions worth flagging

- Non-project IDs exit `2` (same shape as `clarify show` rejecting non-inbox IDs).
- The archive section includes all terminal statuses (`done`, `canceled`, `discarded`, `archived`) — canceled children carry signal too: they're explicit decisions to not pursue something.
- `someday` is excluded — orthodox workflow keeps `someday` items unlinked.

## Test plan

- [x] `mise run lint` — clean
- [x] `mise run test` — all green; 9 new tests cover happy path, section grouping, empty sections, not-found, non-project rejection, archive windowing (default + `--since ''` + custom), all-terminal-statuses inclusion, invalid `--since` parsing, and JSON shape
- [x] End-to-end smoke against the built binary: `htd init` → promote a project with two next-action children → add a linked waiting-for → mark one child done → `htd reflect project ID` and `--json` both render the expected sections
- [x] Negative paths exit `2`: `htd reflect project does-not-exist` and `htd reflect project <next_action_id>` both produce exit code 2