### PR TITLE
feat(capture): land items directly with --kind and --child

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ Creates the full directory layout under the htd root and prints each directory p
 
 ```
 htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]...
+htd capture add --kind project --title TEXT [--child TITLE]...
 ```
+
+`--kind` lands the item directly outside the inbox (`next_action`, `project`, `waiting_for`, `someday`, `tickler`). When `--kind project` is combined with `--child`, the children become linked `next_action` items in one shot.
 
 ### Clarify
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,7 +61,7 @@ For all mutating commands:
 ### 2.1 `htd capture add`
 
 ```
-htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]... [--ref URL]... [--done]
+htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]... [--ref URL]... [--kind KIND] [--child TITLE]... [--done]
 ```
 
 | Option | Req | Description |
@@ -71,16 +71,28 @@ htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]... [--ref
 | `--source` | no | Origin (e.g., `email`, `slack`) |
 | `--tag` | no | Tag; repeatable |
 | `--ref` | no | External URL; repeatable |
-| `--done` | no | Capture as already completed (see below) |
+| `--kind` | no | Land directly as this kind instead of `inbox`. Accepts `next_action`, `project`, `waiting_for`, `someday`, `tickler`. `inbox` is rejected as redundant. |
+| `--child` | no | Child next-action title to create and link; repeatable. Requires `--kind project`. |
+| `--done` | no | Capture as already completed (see below). Mutually exclusive with `--kind` and `--child`. |
 
-**Behavior:** Generate ID, set `kind: inbox`, `status: active`, set `created_at`/`updated_at`, write `items/inbox/<id>.md`, print the ID.
+**Behavior:** Generate ID, set `kind: inbox` (or the `--kind` value), `status: active`, write to `items/<kind>/<id>.md`, print the ID.
+
+**`--kind`:** Skips the inbox and lands the item directly in `items/<kind>/`. Equivalent to `capture add` + `organize move <kind>` collapsed into one step.
+
+**`--child` (with `--kind project`):** After writing the parent project, creates one `next_action` per `--child TITLE` with `project: <parent-id>`. Output then matches `organize promote`: parent ID followed by each child ID, one per line (or `{"parent": "...", "children": [...]}` with `--json`). Empty `--child` titles are rejected.
 
 **`--done`:** Writes directly to `archive/items/<id>.md` with `kind: next_action`, `status: done` (no inbox stop). Metadata flags (`--body`/`--source`/`--tag`/`--ref`) still apply.
 
-Example:
+Examples:
 ```
 $ htd capture add --title "Reply to Alice" --done
 20260420-reply_to_alice
+
+$ htd capture add --kind project --title "Launch v2" \
+    --child "Verify staging" --child "Release to prod"
+20260518-launch_v2
+20260518-verify_staging
+20260518-release_to_prod
 ```
 
 ---
@@ -515,7 +527,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | Command | Description |
 |---------|-------------|
 | `htd init` | Create the htd directory layout |
-| `htd capture add` | Add to inbox (`--done` archives immediately) |
+| `htd capture add` | Add to inbox (`--kind` skips inbox; `--kind project --child ...` seeds children; `--done` archives immediately) |
 | `htd clarify list` / `show ID` / `update ID` / `discard ID` | Process inbox |
 | `htd organize move KIND ID...` | Change kind |
 | `htd organize link ID PROJECT_ID` / `unlink ID` | Manage project link |

--- a/internal/command/capture.go
+++ b/internal/command/capture.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -21,12 +22,14 @@ func newCaptureCommand(c *container) *cobra.Command {
 
 func newCaptureAddCommand(c *container) *cobra.Command {
 	var (
-		title  string
-		body   string
-		source string
-		tags   []string
-		refs   []string
-		done   bool
+		title    string
+		body     string
+		source   string
+		tags     []string
+		refs     []string
+		kindFlag string
+		children []string
+		done     bool
 	)
 
 	cmd := &cobra.Command{
@@ -36,8 +39,12 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 			if title == "" {
 				return fmt.Errorf("--title is required")
 			}
-			now := time.Now()
-			itemID := generateUniqueID(c, title, now)
+			if done && kindFlag != "" {
+				return fmt.Errorf("--done and --kind are mutually exclusive")
+			}
+			if done && len(children) > 0 {
+				return fmt.Errorf("--done and --child are mutually exclusive")
+			}
 
 			kind := model.KindInbox
 			status := model.StatusActive
@@ -47,7 +54,28 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 				// by store.PathForItem because its status is terminal.
 				kind = model.KindNextAction
 				status = model.StatusDone
+			} else if kindFlag != "" {
+				k := model.Kind(kindFlag)
+				if k == model.KindInbox {
+					return fmt.Errorf("--kind inbox is redundant; omit --kind to capture into the inbox")
+				}
+				if !slices.Contains(model.ValidKinds(), k) {
+					return fmt.Errorf("invalid kind %q", kindFlag)
+				}
+				kind = k
 			}
+
+			if len(children) > 0 {
+				if kind != model.KindProject {
+					return fmt.Errorf("--child requires --kind project")
+				}
+				if slices.Contains(children, "") {
+					return fmt.Errorf("--child title must not be empty")
+				}
+			}
+
+			now := time.Now()
+			itemID := generateUniqueID(c, title, now)
 
 			item := &model.Item{
 				ID:        itemID,
@@ -71,7 +99,31 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 			if err := store.Write(path, item, body); err != nil {
 				return err
 			}
-			c.printer.PrintID(itemID)
+
+			if len(children) == 0 {
+				c.printer.PrintID(itemID)
+				return nil
+			}
+
+			childIDs := make([]string, 0, len(children))
+			for _, childTitle := range children {
+				childID := generateUniqueID(c, childTitle, now)
+				child := &model.Item{
+					ID:        childID,
+					Title:     childTitle,
+					Kind:      model.KindNextAction,
+					Status:    model.StatusActive,
+					Project:   item.ID,
+					CreatedAt: now,
+					UpdatedAt: now,
+				}
+				childPath := store.PathForItem(c.cfg, child)
+				if err := store.Write(childPath, child, ""); err != nil {
+					return err
+				}
+				childIDs = append(childIDs, childID)
+			}
+			c.printer.PrintPromote(item.ID, childIDs)
 			return nil
 		},
 	}
@@ -81,6 +133,8 @@ func newCaptureAddCommand(c *container) *cobra.Command {
 	cmd.Flags().StringVar(&source, "source", "", "Origin of the item")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable)")
 	cmd.Flags().StringArrayVar(&refs, "ref", nil, "External reference URL (repeatable)")
+	cmd.Flags().StringVar(&kindFlag, "kind", "", "Land directly as this kind instead of inbox (next_action, project, waiting_for, someday, tickler)")
+	cmd.Flags().StringArrayVar(&children, "child", nil, "Child next-action title to create and link (requires --kind project; repeatable)")
 	cmd.Flags().BoolVar(&done, "done", false, "Capture the item as already completed (lands in archive/items/ with kind=next_action, status=done)")
 
 	return cmd

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -230,6 +230,153 @@ func TestCaptureAddIDFormat(t *testing.T) {
 	}
 }
 
+func TestCaptureAddKindProject(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "capture", "add", "--kind", "project", "--title", "Launch v2")
+	if err != nil {
+		t.Fatalf("capture add --kind project: %v", err)
+	}
+	id := strings.TrimSpace(out)
+	item, _ := readItem(t, dir, id)
+	if item.Kind != model.KindProject {
+		t.Errorf("kind: want project, got %q", item.Kind)
+	}
+	if item.Status != model.StatusActive {
+		t.Errorf("status: want active, got %q", item.Status)
+	}
+
+	cfg := config.New(dir)
+	projectPath := filepath.Join(cfg.DirForKind(model.KindProject), id+".md")
+	if _, err := os.Stat(projectPath); err != nil {
+		t.Errorf("expected item at %q, stat err: %v", projectPath, err)
+	}
+	inboxPath := filepath.Join(cfg.DirForKind(model.KindInbox), id+".md")
+	if _, err := os.Stat(inboxPath); !os.IsNotExist(err) {
+		t.Errorf("expected no item at %q; stat err: %v", inboxPath, err)
+	}
+}
+
+func TestCaptureAddKindNextAction(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "capture", "add", "--kind", "next_action", "--title", "Skip inbox")
+	if err != nil {
+		t.Fatalf("capture add --kind next_action: %v", err)
+	}
+	id := strings.TrimSpace(out)
+	item, _ := readItem(t, dir, id)
+	if item.Kind != model.KindNextAction {
+		t.Errorf("kind: want next_action, got %q", item.Kind)
+	}
+}
+
+func TestCaptureAddKindWithChildren(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "capture", "add",
+		"--kind", "project", "--title", "Launch v2",
+		"--child", "Verify staging", "--child", "Release to prod",
+	)
+	if err != nil {
+		t.Fatalf("capture add --kind project --child: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 IDs printed (parent + 2 children), got %d: %v", len(lines), lines)
+	}
+	parentID := lines[0]
+	parent, _ := readItem(t, dir, parentID)
+	if parent.Kind != model.KindProject {
+		t.Errorf("parent kind: want project, got %q", parent.Kind)
+	}
+	for _, childID := range lines[1:] {
+		child, _ := readItem(t, dir, childID)
+		if child.Kind != model.KindNextAction {
+			t.Errorf("child %s kind: want next_action, got %q", childID, child.Kind)
+		}
+		if child.Project != parentID {
+			t.Errorf("child %s project: want %q, got %q", childID, parentID, child.Project)
+		}
+	}
+}
+
+func TestCaptureAddKindWithChildrenJSON(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "--json", "capture", "add",
+		"--kind", "project", "--title", "Launch v2",
+		"--child", "Verify staging",
+	)
+	if err != nil {
+		t.Fatalf("capture add --json: %v", err)
+	}
+	var got struct {
+		Parent   string   `json:"parent"`
+		Children []string `json:"children"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if got.Parent == "" || len(got.Children) != 1 {
+		t.Errorf("unexpected JSON shape: %+v", got)
+	}
+}
+
+func TestCaptureAddKindInboxRejected(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "capture", "add", "--kind", "inbox", "--title", "Why")
+	if err == nil {
+		t.Fatal("expected error for --kind inbox")
+	}
+	if !strings.Contains(err.Error(), "redundant") {
+		t.Errorf("error should explain redundancy, got %v", err)
+	}
+}
+
+func TestCaptureAddKindInvalid(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "capture", "add", "--kind", "bogus", "--title", "Why")
+	if err == nil {
+		t.Fatal("expected error for invalid kind")
+	}
+	if !strings.Contains(err.Error(), "invalid kind") {
+		t.Errorf("error should mention invalid kind, got %v", err)
+	}
+}
+
+func TestCaptureAddChildRequiresProjectKind(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "capture", "add",
+		"--kind", "next_action", "--title", "Solo task", "--child", "Sub",
+	)
+	if err == nil {
+		t.Fatal("expected error when --child used without --kind project")
+	}
+	if !strings.Contains(err.Error(), "--child requires --kind project") {
+		t.Errorf("error should explain --child requires project kind, got %v", err)
+	}
+}
+
+func TestCaptureAddChildEmptyTitleRejected(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "capture", "add",
+		"--kind", "project", "--title", "P", "--child", "",
+	)
+	if err == nil {
+		t.Fatal("expected error for empty --child title")
+	}
+}
+
+func TestCaptureAddDoneConflictsWithKind(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "capture", "add",
+		"--title", "X", "--done", "--kind", "project",
+	)
+	if err == nil {
+		t.Fatal("expected error for --done with --kind")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutual exclusion, got %v", err)
+	}
+}
+
 // ---------- clarify ----------
 
 func TestClarifyList(t *testing.T) {

--- a/plugins/htd/commands/capture.md
+++ b/plugins/htd/commands/capture.md
@@ -45,6 +45,22 @@ htd capture add --title "<title>" --done
 
 This lands the item directly in `archive/items/` with `kind: next_action`, `status: done` — no stop in the inbox, no follow-up `engage done` needed. `--body`, `--source`, and `--tag` still apply. Prefer this over `capture add` + `engage done <id>` for anything the user has already completed.
 
+## Skip-inbox shortcut (`--kind`)
+
+If the disposition is already clear at capture time ("this is a project called X with sub-tasks A and B", "this is a tickler for next Monday"), pass `--kind` to land directly in the right list and skip clarify. With `--kind project`, repeat `--child "<title>"` to seed linked next-action children in the same call:
+
+```bash
+# Project + first sub-actions in one step
+htd capture add --kind project --title "<project title>" \
+  --child "<first sub-action>" [--child "<more>"]...
+
+# Skip-inbox for non-project kinds
+htd capture add --kind next_action --title "<title>"
+htd capture add --kind tickler --title "<title>"
+```
+
+Only use this when the user is unambiguous about disposition; when in doubt, stay on the default `capture add` (lands in inbox) and let `/htd:clarify` decide. `--kind inbox` is rejected (redundant with the default); `--child` requires `--kind project`; `--kind` and `--done` are mutually exclusive.
+
 ## Notes
 
 - Titles stay in English per project convention.

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -95,6 +95,8 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 **Capture**
 - `htd capture add --title TEXT [--body TEXT] [--source NAME] [--tag TAG]...`
 - `htd capture add --title TEXT --done [--body TEXT] [--source NAME] [--tag TAG]...` — capture an already-completed item. Bypasses the inbox; the item lands directly in `archive/items/` with `kind: next_action`, `status: done`. Prefer this over `capture add` followed by `engage done <id>` when the user has already finished the task.
+- `htd capture add --kind KIND --title TEXT` — skip the inbox and land directly as `next_action`, `project`, `waiting_for`, `someday`, or `tickler` when the disposition is obvious at capture time.
+- `htd capture add --kind project --title TEXT --child "<sub-title>"...` — create a project and seed linked next-action children in one shot. Prefer this over the multi-step capture+move+capture+link chain when the user names sub-actions up front.
 
 **Clarify** (inbox only)
 - `htd clarify list`


### PR DESCRIPTION
Closes #47.

## Summary

- `htd capture add --kind KIND` lands the item directly in `items/<kind>/` instead of `items/inbox/`. Accepts `next_action`, `project`, `waiting_for`, `someday`, `tickler`. Mirrors the existing `--done` precedent of capture-with-disposition.
- `htd capture add --kind project --child TITLE [--child TITLE]...` creates the project and seeds linked next-action children in a single call, reusing the `organize promote` output shape (parent ID + each child ID; `{"parent":..., "children":[...]}` in JSON mode).
- Collapses the 5-step orthodox project-creation flow (capture, move-to-project, capture-child, move-to-next_action, link) into one command.

## Constraints

- `--kind inbox` is rejected as redundant; omit `--kind` to capture into the inbox.
- `--child` requires `--kind project`; empty `--child` titles are rejected.
- `--done` is mutually exclusive with `--kind` and `--child`.

## Test plan

- [x] `mise run build` / `test` / `lint` all green.
- [x] New tests cover: each kind happy path, project + children (text and JSON output), `--kind inbox` rejection, invalid kind, `--child` without project kind, empty `--child` title, `--done` + `--kind` conflict.
- [x] Manual smoke against a scratch htd root for every flag combination.
- [x] Docs updated: `docs/cli.md` §2.1 + command summary, `README.md`, `plugins/htd/commands/capture.md`, `plugins/htd/skills/htd-workflow/SKILL.md`.