### PR TITLE
fix(reflect log): make --since optional with 30-day default

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -189,18 +189,18 @@ All active items where `review_at` is today or past. Columns: `ID`, `TITLE`, `KI
 ### 5.5 `htd reflect log`
 
 ```
-htd reflect log --since DATE [--until DATE] [--kind KIND] [--tag TAG]... [--status STATUS]...
+htd reflect log [--since DATE] [--until DATE] [--kind KIND] [--tag TAG]... [--status STATUS]...
 ```
 
 | Option | Req | Description |
 |--------|-----|-------------|
-| `--since` | yes | Updated on/after this date (`YYYY-MM-DD`) |
+| `--since` | no | Updated on/after this date (`YYYY-MM-DD`). Default: 30 days ago. Pass `--since ""` to show all. |
 | `--until` | no | Updated on/before (inclusive end-of-day) |
 | `--kind` | no | Filter by kind |
 | `--tag` | no | Filter by tag; repeatable (AND) |
 | `--status` | no | Terminal status filter; repeatable. Values: `done`, `canceled`, `discarded`, `archived`. Default: `done`. |
 
-Reads `archive/items/`. Columns: `ID`, `KIND`, `STATUS`, `UPDATED_AT`, `TITLE`. Sort by `updated_at` descending.
+Reads `archive/items/`. Columns: `ID`, `KIND`, `STATUS`, `UPDATED_AT`, `TITLE`. Sort by `updated_at` descending. JSON output is always a valid array — empty results render as `[]`.
 
 ### 5.6 `htd reflect tickler [--pull]`
 
@@ -534,7 +534,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd organize schedule ID` | Set dates |
 | `htd organize promote ID --child TITLE...` | Promote to project with children |
 | `htd reflect next-actions` / `projects [--stalled]` / `waiting` / `review` | List views |
-| `htd reflect log --since DATE` | Activity log of resolved items |
+| `htd reflect log [--since DATE]` | Activity log of resolved items (default: last 30 days) |
 | `htd reflect tickler [--pull]` | Fired ticklers, optionally pull to inbox |
 | `htd reflect project ID` | Project with active + archived children |
 | `htd engage done ID...` / `cancel ID...` | Terminal transitions |

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1929,6 +1929,64 @@ func TestReflectLogInvalidStatus(t *testing.T) {
 	}
 }
 
+func TestReflectLogDefaultsToRecentWindow(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	recent := nowItem("20260518-recent_done", model.KindNextAction, model.StatusDone)
+	stale := &model.Item{
+		ID: "20251231-stale_done", Title: "stale", Kind: model.KindNextAction, Status: model.StatusDone,
+		CreatedAt: now.AddDate(0, 0, -90),
+		UpdatedAt: now.AddDate(0, 0, -90),
+	}
+	writeItem(t, dir, recent, "")
+	writeItem(t, dir, stale, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "log")
+	if err != nil {
+		t.Fatalf("reflect log (no --since): %v", err)
+	}
+	if !strings.Contains(out, "20260518-recent_done") {
+		t.Errorf("recent item should be in default window: %q", out)
+	}
+	if strings.Contains(out, "20251231-stale_done") {
+		t.Errorf("item older than 30-day default should be excluded: %q", out)
+	}
+}
+
+func TestReflectLogSinceEmptyShowsAll(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	stale := &model.Item{
+		ID: "20251231-stale_done", Title: "stale", Kind: model.KindNextAction, Status: model.StatusDone,
+		CreatedAt: now.AddDate(0, 0, -90),
+		UpdatedAt: now.AddDate(0, 0, -90),
+	}
+	writeItem(t, dir, stale, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "log", "--since", "")
+	if err != nil {
+		t.Fatalf("reflect log --since '': %v", err)
+	}
+	if !strings.Contains(out, "20251231-stale_done") {
+		t.Errorf("--since '' should include items older than default window: %q", out)
+	}
+}
+
+func TestReflectLogJSONEmpty(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "reflect", "log", "--json")
+	if err != nil {
+		t.Fatalf("reflect log --json (no args): %v", err)
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(out), &arr); err != nil {
+		t.Fatalf("output should be a valid JSON array, got %q: %v", out, err)
+	}
+	if len(arr) != 0 {
+		t.Errorf("empty repo should yield empty array, got %d items", len(arr))
+	}
+}
+
 func TestReflectTickler(t *testing.T) {
 	dir := setupDir(t)
 	now := time.Now()

--- a/internal/command/reflect.go
+++ b/internal/command/reflect.go
@@ -51,7 +51,7 @@ func newReflectProjectCommand(c *container) *cobra.Command {
 				return &store.NotFoundError{Kind: store.EntityItem, ID: projectID}
 			}
 
-			cutoff, err := resolveProjectArchiveCutoff(cmd, since, archiveDefaultDays)
+			cutoff, err := resolveSinceCutoff(cmd, since, archiveDefaultDays)
 			if err != nil {
 				return err
 			}
@@ -119,12 +119,13 @@ func newReflectProjectCommand(c *container) *cobra.Command {
 	return cmd
 }
 
-// resolveProjectArchiveCutoff returns the cutoff time for the archive
-// section of `reflect project`. The flag's three-state behavior is:
+// resolveSinceCutoff returns the lower-bound time implied by a --since flag
+// across commands that share the same three-state semantics (reflect project,
+// reflect log). The flag behaves as:
 //   - flag absent → default cutoff (now minus defaultDays)
 //   - --since YYYY-MM-DD → cutoff at that date, local midnight
 //   - --since '' (explicitly empty) → zero time, meaning "no cutoff"
-func resolveProjectArchiveCutoff(cmd *cobra.Command, since string, defaultDays int) (time.Time, error) {
+func resolveSinceCutoff(cmd *cobra.Command, since string, defaultDays int) (time.Time, error) {
 	flag := cmd.Flags().Lookup("since")
 	if flag == nil || !flag.Changed {
 		return time.Now().AddDate(0, 0, -defaultDays), nil
@@ -262,6 +263,7 @@ func newReflectReviewCommand(c *container) *cobra.Command {
 }
 
 func newReflectLogCommand(c *container) *cobra.Command {
+	const logDefaultDays = 30
 	var (
 		since    string
 		until    string
@@ -274,9 +276,9 @@ func newReflectLogCommand(c *container) *cobra.Command {
 		Use:   "log",
 		Short: "List recently resolved items (activity log)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sinceTime, err := time.ParseInLocation("2006-01-02", since, time.Local)
+			sinceTime, err := resolveSinceCutoff(cmd, since, logDefaultDays)
 			if err != nil {
-				return fmt.Errorf("--since: cannot parse %q as date", since)
+				return err
 			}
 
 			var untilEnd time.Time
@@ -336,12 +338,12 @@ func newReflectLogCommand(c *container) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&since, "since", "", "Show items updated on or after this date (YYYY-MM-DD)")
+	cmd.Flags().StringVar(&since, "since", "",
+		"Show items updated on or after this date (YYYY-MM-DD); default is 30 days ago, pass --since '' to show all")
 	cmd.Flags().StringVar(&until, "until", "", "Show items updated on or before this date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&kindStr, "kind", "", "Filter by kind")
 	cmd.Flags().StringSliceVar(&tags, "tag", nil, "Filter by tag (repeatable)")
 	cmd.Flags().StringSliceVar(&statuses, "status", nil, "Filter by terminal status (repeatable; default: done)")
-	_ = cmd.MarkFlagRequired("since")
 	return cmd
 }
 

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -115,7 +115,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 - `htd reflect projects [--stalled]`
 - `htd reflect waiting`
 - `htd reflect review` — items whose `review_at` is due.
-- `htd reflect log --since YYYY-MM-DD [--until DATE] [--kind KIND] [--tag TAG]... [--status STATUS]...` — recently resolved items (activity log). Defaults to `--status done`.
+- `htd reflect log [--since YYYY-MM-DD] [--until DATE] [--kind KIND] [--tag TAG]... [--status STATUS]...` — recently resolved items (activity log). `--since` defaults to 30 days ago; pass `--since ""` for all-time. Defaults to `--status done`.
 - `htd reflect tickler [--pull]` — ticklers whose `defer_until` (or `review_at` fallback) is today or past. With `--pull`, move them into the inbox for re-clarification (clears `defer_until`, keeps `review_at`).
 
 **Engage** (act on the system)


### PR DESCRIPTION
Closes #48.

## Summary

`htd reflect log --json` (with no other flags) previously failed the required-flag check and emitted a non-JSON error to stderr with an empty stdout, breaking downstream JSON parsers (`json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`).

This PR:

- Drops the `MarkFlagRequired("since")` on `htd reflect log`.
- Defaults `--since` to 30 days ago when omitted.
- Reuses the existing three-state cutoff helper from `reflect project` (renamed `resolveProjectArchiveCutoff` → `resolveSinceCutoff` to reflect the shared semantics): flag absent → 30 days back, `--since YYYY-MM-DD` → that date, `--since ""` → no cutoff (all-time).

The empty-results JSON path was already correct (`printItemsJSON` uses `make()` so `json.Marshal` always yields `[]`); it is now reachable from the bare `--json` invocation.

## Test plan

- [x] `mise run build` / `test` / `lint` green.
- [x] New tests: default 30-day window excludes a 90-day-old item; `--since ""` includes it; `--json` on an empty repo emits a valid empty array.
- [x] Manual smoke confirming the original repro is fixed.
- [x] Docs updated: `docs/cli.md` §5.5 + command summary, `plugins/htd/skills/htd-workflow/SKILL.md`. Other plugin guides keep their explicit `--since` dates since those windows are intentional.