### PR TITLE
feat(reflect tickler): add --all and --pending visibility flags

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -202,12 +202,18 @@ htd reflect log [--since DATE] [--until DATE] [--kind KIND] [--tag TAG]... [--st
 
 Reads `archive/items/`. Columns: `ID`, `KIND`, `STATUS`, `UPDATED_AT`, `TITLE`. Sort by `updated_at` descending. JSON output is always a valid array — empty results render as `[]`.
 
-### 5.6 `htd reflect tickler [--pull]`
+### 5.6 `htd reflect tickler [--pull] [--all | --pending]`
 
-`items/tickler/`, `status: active`. Trigger = `defer_until` else `review_at`; skip if both absent. Keep items whose trigger is today or past, sort ascending.
+`items/tickler/`, `status: active`. Trigger = `defer_until` else `review_at`; skip if both absent. Sort by trigger ascending.
+
+Visibility flags (mutually exclusive):
+
+- Default: fired only — items whose trigger is today or past.
+- `--pending`: pending only — items whose trigger is in the future.
+- `--all`: both fired and pending in one list (`--all` is the weekly-review view: "what just fired plus what's coming back").
 
 - Without `--pull`: print `ID`, `TITLE`, `DEFER_UNTIL`. No state change.
-- With `--pull`: for each item in order, set `kind: inbox`, clear `defer_until` (preserve `review_at`), move to `items/inbox/<id>.md`, print the ID.
+- With `--pull`: for each fired item in order, set `kind: inbox`, clear `defer_until` (preserve `review_at`), move to `items/inbox/<id>.md`, print the ID. `--pull` rejects `--all`/`--pending` since pending items have nothing to pull.
 
 Pulled items flow through normal clarify; a fired tickler is a re-decide prompt, not auto-promotion.
 
@@ -535,7 +541,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd organize promote ID --child TITLE...` | Promote to project with children |
 | `htd reflect next-actions` / `projects [--stalled]` / `waiting` / `review` | List views |
 | `htd reflect log [--since DATE]` | Activity log of resolved items (default: last 30 days) |
-| `htd reflect tickler [--pull]` | Fired ticklers, optionally pull to inbox |
+| `htd reflect tickler [--pull \| --all \| --pending]` | Fired (default), pending, or both; `--pull` empties fired into the inbox |
 | `htd reflect project ID` | Project with active + archived children |
 | `htd engage done ID...` / `cancel ID...` | Terminal transitions |
 | `htd engage next-actions` / `waiting` | Pick work now |

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -2155,6 +2155,84 @@ func TestReflectTicklerPullJSONEmpty(t *testing.T) {
 	}
 }
 
+func TestReflectTicklerPending(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	past := now.Add(-24 * time.Hour)
+	future := now.Add(24 * time.Hour)
+
+	fired := nowItem("20260417-tick_fired", model.KindTickler, model.StatusActive)
+	fired.DeferUntil = &past
+	writeItem(t, dir, fired, "")
+
+	pending := nowItem("20260518-tick_pending", model.KindTickler, model.StatusActive)
+	pending.DeferUntil = &future
+	writeItem(t, dir, pending, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "tickler", "--pending")
+	if err != nil {
+		t.Fatalf("reflect tickler --pending: %v", err)
+	}
+	if !strings.Contains(out, "20260518-tick_pending") {
+		t.Errorf("--pending should include future tickler: %q", out)
+	}
+	if strings.Contains(out, "20260417-tick_fired") {
+		t.Errorf("--pending should exclude fired tickler: %q", out)
+	}
+}
+
+func TestReflectTicklerAll(t *testing.T) {
+	dir := setupDir(t)
+	now := time.Now()
+	past := now.Add(-48 * time.Hour)
+	future := now.Add(24 * time.Hour)
+
+	fired := nowItem("20260417-tick_fired", model.KindTickler, model.StatusActive)
+	fired.DeferUntil = &past
+	writeItem(t, dir, fired, "")
+
+	pending := nowItem("20260518-tick_pending", model.KindTickler, model.StatusActive)
+	pending.DeferUntil = &future
+	writeItem(t, dir, pending, "")
+
+	out, _, err := runCmd(t, dir, "reflect", "tickler", "--all")
+	if err != nil {
+		t.Fatalf("reflect tickler --all: %v", err)
+	}
+	firedIdx := strings.Index(out, "20260417-tick_fired")
+	pendingIdx := strings.Index(out, "20260518-tick_pending")
+	if firedIdx == -1 || pendingIdx == -1 {
+		t.Fatalf("--all should include both fired and pending: %q", out)
+	}
+	if firedIdx > pendingIdx {
+		t.Errorf("--all should sort by trigger ascending (fired before pending), got:\n%s", out)
+	}
+}
+
+func TestReflectTicklerAllPendingConflict(t *testing.T) {
+	dir := setupDir(t)
+	_, _, err := runCmd(t, dir, "reflect", "tickler", "--all", "--pending")
+	if err == nil {
+		t.Fatal("expected error when --all and --pending are combined")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutual exclusion, got %v", err)
+	}
+}
+
+func TestReflectTicklerPullConflict(t *testing.T) {
+	dir := setupDir(t)
+	for _, mode := range []string{"--all", "--pending"} {
+		_, _, err := runCmd(t, dir, "reflect", "tickler", "--pull", mode)
+		if err == nil {
+			t.Errorf("expected error for --pull %s", mode)
+		}
+		if err != nil && !strings.Contains(err.Error(), "--pull only applies to fired") {
+			t.Errorf("error should explain --pull constraint, got %v", err)
+		}
+	}
+}
+
 // ---------- item ----------
 
 func TestItemGet(t *testing.T) {

--- a/internal/command/reflect.go
+++ b/internal/command/reflect.go
@@ -348,12 +348,23 @@ func newReflectLogCommand(c *container) *cobra.Command {
 }
 
 func newReflectTicklerCommand(c *container) *cobra.Command {
-	var pull bool
+	var (
+		pull    bool
+		all     bool
+		pending bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "tickler",
 		Short: "List fired tickler items, or pull them into the inbox with --pull",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if all && pending {
+				return fmt.Errorf("--all and --pending are mutually exclusive")
+			}
+			if pull && (all || pending) {
+				return fmt.Errorf("--pull only applies to fired ticklers; remove --all/--pending")
+			}
+
 			kind := model.KindTickler
 			status := model.StatusActive
 			items, err := store.List(c.cfg, store.Filter{Kind: &kind, Status: &status})
@@ -363,27 +374,34 @@ func newReflectTicklerCommand(c *container) *cobra.Command {
 			now := time.Now()
 			todayEnd := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 0, now.Location())
 
-			var due []*model.Item
+			var selected []*model.Item
 			triggers := make(map[string]time.Time)
 			for _, it := range items {
 				trigger := ticklerTrigger(it)
-				if trigger == nil || trigger.After(todayEnd) {
+				if trigger == nil {
 					continue
 				}
-				due = append(due, it)
+				fired := !trigger.After(todayEnd)
+				switch {
+				case pending && fired:
+					continue
+				case !all && !pending && !fired:
+					continue
+				}
+				selected = append(selected, it)
 				triggers[it.ID] = *trigger
 			}
-			sort.Slice(due, func(i, j int) bool {
-				return triggers[due[i].ID].Before(triggers[due[j].ID])
+			sort.Slice(selected, func(i, j int) bool {
+				return triggers[selected[i].ID].Before(triggers[selected[j].ID])
 			})
 
 			if !pull {
-				c.printer.PrintItems(due)
+				c.printer.PrintItems(selected)
 				return nil
 			}
 
-			pulled := make([]string, 0, len(due))
-			for _, it := range due {
+			pulled := make([]string, 0, len(selected))
+			for _, it := range selected {
 				src := store.PathForItem(c.cfg, it)
 				full, body, err := store.Read(src)
 				if err != nil {
@@ -404,6 +422,8 @@ func newReflectTicklerCommand(c *container) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&pull, "pull", false, "Move fired tickler items into the inbox")
+	cmd.Flags().BoolVar(&all, "all", false, "Include pending (future-dated) ticklers alongside fired ones")
+	cmd.Flags().BoolVar(&pending, "pending", false, "Show only pending (future-dated) ticklers")
 	return cmd
 }
 

--- a/plugins/htd/commands/weekly-review.md
+++ b/plugins/htd/commands/weekly-review.md
@@ -63,6 +63,14 @@ htd reflect tickler --pull
 
 Hand off to `/htd:clarify` to process the pulled items.
 
+After emptying, surface what's queued for the coming weeks so the user knows what's coming back:
+
+```bash
+htd reflect tickler --pending --json
+```
+
+This is awareness, not action — no `--pull` here.
+
 ---
 
 ## Phase B — Get Current

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -116,7 +116,7 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 - `htd reflect waiting`
 - `htd reflect review` — items whose `review_at` is due.
 - `htd reflect log [--since YYYY-MM-DD] [--until DATE] [--kind KIND] [--tag TAG]... [--status STATUS]...` — recently resolved items (activity log). `--since` defaults to 30 days ago; pass `--since ""` for all-time. Defaults to `--status done`.
-- `htd reflect tickler [--pull]` — ticklers whose `defer_until` (or `review_at` fallback) is today or past. With `--pull`, move them into the inbox for re-clarification (clears `defer_until`, keeps `review_at`).
+- `htd reflect tickler [--pull | --all | --pending]` — by default, ticklers whose `defer_until` (or `review_at` fallback) is today or past. `--pending` shows future-dated ticklers; `--all` shows both. With `--pull`, move fired items into the inbox for re-clarification (clears `defer_until`, keeps `review_at`); `--pull` rejects `--all`/`--pending`.
 
 **Engage** (act on the system)
 - `htd engage next-actions [--project ID] [--tag T]...` — what's ready to work on now.


### PR DESCRIPTION
Closes #49.

## Summary

Previously `htd reflect tickler` only showed fired ticklers (trigger in the past). Verifying a freshly-scheduled tickler or previewing what's coming back required dropping to `find` or reading raw frontmatter.

This PR adds two mutually exclusive visibility flags:

- Default: fired only (unchanged).
- `--pending`: future-dated ticklers only.
- `--all`: both fired and pending, sorted by trigger ascending — the weekly-review view of "what just fired plus what's coming back".

`--pull` is unchanged in semantics (move fired items into the inbox) and now rejects `--all`/`--pending` since pending items have nothing to pull.

## Test plan

- [x] `mise run build` / `test` / `lint` green.
- [x] New tests: `--pending` excludes fired, `--all` includes both with correct sort order, `--all + --pending` rejected, `--pull + --all`/`--pull + --pending` rejected.
- [x] Manual smoke against a scratch htd root covering all flag combos.
- [x] Docs updated: `docs/cli.md` §5.6 + command summary, `plugins/htd/skills/htd-workflow/SKILL.md`, and the weekly-review plugin gains a 'preview pending' step right after the fired-pull step.