### PR TITLE
feat(tag): enumerate tags with htd tag list

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ htd item archive ID
 htd item restore ID
 ```
 
+### Tag survey
+
+```
+htd tag list [--similar TAG]
+```
+
+Enumerate every tag in use with its item count. `--similar` surfaces near-matches (Levenshtein distance ≤ 3, or normalized-form collision) — useful before introducing a new tag to avoid drift like `ivry_job_scheduler` vs `ivry-job-scheduler`.
+
 ## Global options
 
 | Option | Default | Description |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -493,9 +493,51 @@ Read `journal/<NAME>.md`. Display frontmatter (if present) then body. Exit `2` i
 
 ---
 
-## 10. Init
+## 10. Tag
 
-### 10.1 `htd init`
+Tag-level operations across items. References' `type:*` tags are not aggregated here; they follow a formal enum and don't drift.
+
+### 10.1 `htd tag list [--similar TAG]`
+
+Enumerate every tag used on items (active + archived) with its item count. Helps surface drift before introducing a new tag (e.g., `ivry_job_scheduler` vs `ivry-job-scheduler`).
+
+| Option | Req | Description |
+|--------|-----|-------------|
+| `--similar` | no | Narrow to tags that look like the supplied value. A tag matches if its Levenshtein distance from `TAG` is ≤ 3, or its normalized form collides with the normalized `TAG`. Normalization lowercases and strips everything outside `[a-z0-9]`, so `admin_ivry_jp`, `admin.ivry.jp`, and `AdminIvryJP` all collapse to one group. |
+
+**Output:**
+
+- Text: `TAG`, `COUNT`. Sort by count desc, tag asc as tiebreaker. With `--similar`, an extra `DISTANCE` column is shown and rows sort by (distance asc, count desc, tag asc).
+- JSON: `[{"tag": "...", "count": N}, ...]`. `distance` is intentionally omitted to keep the JSON shape independent of `--similar`. Empty repo renders as `[]`.
+
+Tags are case-sensitive throughout htd, so `Bug` and `bug` count separately — that's the signal the command is designed to surface.
+
+**Examples:**
+
+```
+$ htd tag list
+TAG                   COUNT
+bug                   12
+docs                  7
+ivry_job_scheduler    5
+ivry-job-scheduler    1
+
+$ htd tag list --similar ivry_job_scheduler
+TAG                   COUNT  DISTANCE
+ivry_job_scheduler    5      0
+ivry-job-scheduler    1      2
+
+$ htd tag list --similar admin_ivry_jp
+TAG                COUNT  DISTANCE
+admin.ivry.jp      3      2
+adminivryjp        1      4
+```
+
+---
+
+## 11. Init
+
+### 11.1 `htd init`
 
 Create the directory layout (see `docs/datamodel.md §7`) under `--path` and print the set, one path per line, stable order. Idempotent. Other commands also create missing directories as a side effect; `init` makes setup explicit. JSON: array of directory paths.
 
@@ -515,9 +557,9 @@ journal
 
 ---
 
-## 11. Completion
+## 12. Completion
 
-### 11.1 `htd completion SHELL`
+### 12.1 `htd completion SHELL`
 
 Emit completion script for `bash`, `zsh`, `fish`, or `powershell` to stdout. Covers all groups, subcommands, flags. Does not touch `--path`; safe anywhere.
 
@@ -528,7 +570,7 @@ htd completion zsh > "${fpath[1]}/_htd"
 
 ---
 
-## 12. Command Summary
+## 13. Command Summary
 
 | Command | Description |
 |---------|-------------|
@@ -548,4 +590,5 @@ htd completion zsh > "${fpath[1]}/_htd"
 | `htd item get ID` / `list` / `update ID` / `archive ID` / `restore ID` | Low-level CRUD |
 | `htd reference add` / `get` / `list` / `update` / `archive` / `restore` / `reindex` | Tool-scoped notes |
 | `htd journal new` / `list` / `show NAME` | Journal entries |
+| `htd tag list [--similar TAG]` | List tags in use with counts; `--similar` surfaces near-matches |
 | `htd completion SHELL` | Shell completion |

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -2823,6 +2823,164 @@ func TestItemRestoreNotFound(t *testing.T) {
 	}
 }
 
+// ---------- tag ----------
+
+func writeTaggedItem(t *testing.T, dir, id string, kind model.Kind, status model.Status, tags []string) {
+	t.Helper()
+	item := nowItem(id, kind, status)
+	item.Tags = tags
+	writeItem(t, dir, item, "")
+}
+
+func TestTagList(t *testing.T) {
+	dir := setupDir(t)
+	writeTaggedItem(t, dir, "20260518-a", model.KindNextAction, model.StatusActive, []string{"bug", "docs"})
+	writeTaggedItem(t, dir, "20260518-b", model.KindNextAction, model.StatusActive, []string{"bug"})
+	writeTaggedItem(t, dir, "20260518-c", model.KindProject, model.StatusActive, []string{"docs"})
+	writeTaggedItem(t, dir, "20260518-d", model.KindNextAction, model.StatusActive, nil)
+
+	out, _, err := runCmd(t, dir, "tag", "list")
+	if err != nil {
+		t.Fatalf("tag list: %v", err)
+	}
+	if !strings.Contains(out, "TAG") || !strings.Contains(out, "COUNT") {
+		t.Errorf("missing header: %q", out)
+	}
+	for _, want := range []string{"bug", "docs"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing tag %q in output:\n%s", want, out)
+		}
+	}
+	bugIdx := strings.Index(out, "bug")
+	docsIdx := strings.Index(out, "docs")
+	if bugIdx == -1 || docsIdx == -1 {
+		t.Fatalf("expected both tags; got %q", out)
+	}
+	if bugIdx > docsIdx {
+		t.Errorf("count desc tiebreaker by alpha: bug(2) should precede docs(2), got:\n%s", out)
+	}
+}
+
+func TestTagListSortByCount(t *testing.T) {
+	dir := setupDir(t)
+	writeTaggedItem(t, dir, "20260518-a", model.KindNextAction, model.StatusActive, []string{"hot"})
+	writeTaggedItem(t, dir, "20260518-b", model.KindNextAction, model.StatusActive, []string{"hot"})
+	writeTaggedItem(t, dir, "20260518-c", model.KindNextAction, model.StatusActive, []string{"hot"})
+	writeTaggedItem(t, dir, "20260518-d", model.KindNextAction, model.StatusActive, []string{"cold"})
+
+	out, _, err := runCmd(t, dir, "tag", "list")
+	if err != nil {
+		t.Fatalf("tag list: %v", err)
+	}
+	hotIdx := strings.Index(out, "hot")
+	coldIdx := strings.Index(out, "cold")
+	if hotIdx == -1 || coldIdx == -1 {
+		t.Fatalf("missing tags: %q", out)
+	}
+	if hotIdx > coldIdx {
+		t.Errorf("higher count should appear first: hot(3) before cold(1), got:\n%s", out)
+	}
+}
+
+func TestTagListIncludesArchived(t *testing.T) {
+	dir := setupDir(t)
+	writeTaggedItem(t, dir, "20260101-old_done", model.KindNextAction, model.StatusDone, []string{"legacy_tag"})
+
+	out, _, err := runCmd(t, dir, "tag", "list")
+	if err != nil {
+		t.Fatalf("tag list: %v", err)
+	}
+	if !strings.Contains(out, "legacy_tag") {
+		t.Errorf("archived item's tag should appear: %q", out)
+	}
+}
+
+func TestTagListSimilarLevenshtein(t *testing.T) {
+	dir := setupDir(t)
+	writeTaggedItem(t, dir, "20260518-a", model.KindNextAction, model.StatusActive, []string{"ivry_job_scheduler"})
+	writeTaggedItem(t, dir, "20260518-b", model.KindNextAction, model.StatusActive, []string{"ivry-job-scheduler"})
+	writeTaggedItem(t, dir, "20260518-c", model.KindNextAction, model.StatusActive, []string{"totally_unrelated"})
+
+	out, _, err := runCmd(t, dir, "tag", "list", "--similar", "ivry_job_scheduler")
+	if err != nil {
+		t.Fatalf("tag list --similar: %v", err)
+	}
+	if !strings.Contains(out, "ivry_job_scheduler") {
+		t.Errorf("exact match should appear: %q", out)
+	}
+	if !strings.Contains(out, "ivry-job-scheduler") {
+		t.Errorf("levenshtein-neighbor should appear: %q", out)
+	}
+	if strings.Contains(out, "totally_unrelated") {
+		t.Errorf("unrelated tag should not appear: %q", out)
+	}
+	if !strings.Contains(out, "DISTANCE") {
+		t.Errorf("--similar should include DISTANCE column: %q", out)
+	}
+}
+
+func TestTagListSimilarNormalization(t *testing.T) {
+	dir := setupDir(t)
+	writeTaggedItem(t, dir, "20260518-a", model.KindNextAction, model.StatusActive, []string{"admin.ivry.jp"})
+	writeTaggedItem(t, dir, "20260518-b", model.KindNextAction, model.StatusActive, []string{"adminivryjp"})
+	writeTaggedItem(t, dir, "20260518-c", model.KindNextAction, model.StatusActive, []string{"unrelated"})
+
+	out, _, err := runCmd(t, dir, "tag", "list", "--similar", "admin_ivry_jp")
+	if err != nil {
+		t.Fatalf("tag list --similar: %v", err)
+	}
+	if !strings.Contains(out, "admin.ivry.jp") {
+		t.Errorf("punctuation variant should match via normalization: %q", out)
+	}
+	if !strings.Contains(out, "adminivryjp") {
+		t.Errorf("normalized variant should match: %q", out)
+	}
+	if strings.Contains(out, "unrelated") {
+		t.Errorf("unrelated tag should not appear: %q", out)
+	}
+}
+
+func TestTagListJSONEmpty(t *testing.T) {
+	dir := setupDir(t)
+	out, _, err := runCmd(t, dir, "tag", "list", "--json")
+	if err != nil {
+		t.Fatalf("tag list --json: %v", err)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("output should be a valid JSON array, got %q: %v", out, err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("empty repo should yield empty array, got %d rows", len(rows))
+	}
+}
+
+func TestTagListJSONShape(t *testing.T) {
+	dir := setupDir(t)
+	writeTaggedItem(t, dir, "20260518-a", model.KindNextAction, model.StatusActive, []string{"bug"})
+
+	out, _, err := runCmd(t, dir, "tag", "list", "--similar", "bug", "--json")
+	if err != nil {
+		t.Fatalf("tag list --similar --json: %v", err)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("json parse: %v; out=%q", err, out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d: %q", len(rows), out)
+	}
+	if rows[0]["tag"] != "bug" {
+		t.Errorf("tag field: want bug, got %v", rows[0]["tag"])
+	}
+	if _, ok := rows[0]["count"]; !ok {
+		t.Errorf("missing count field: %v", rows[0])
+	}
+	if _, ok := rows[0]["distance"]; ok {
+		t.Errorf("distance field must not leak into JSON: %v", rows[0])
+	}
+}
+
 // ---------- init ----------
 
 func TestInitCreatesDirectories(t *testing.T) {

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -59,6 +59,7 @@ func NewRootCommand() *cobra.Command {
 	root.AddCommand(newItemCommand(&c))
 	root.AddCommand(newReferenceCommand(&c))
 	root.AddCommand(newJournalCommand(&c))
+	root.AddCommand(newTagCommand(&c))
 
 	return root
 }

--- a/internal/command/similarity.go
+++ b/internal/command/similarity.go
@@ -1,0 +1,63 @@
+package command
+
+import "strings"
+
+// levenshtein returns the edit distance between a and b using a standard
+// two-row dynamic-programming table.
+func levenshtein(a, b string) int {
+	ar := []rune(a)
+	br := []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+	prev := make([]int, len(br)+1)
+	curr := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		curr[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			curr[j] = min3(del, ins, sub)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(br)]
+}
+
+func min3(a, b, c int) int {
+	m := min(b, a)
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+// normalizeTag lowercases the input and strips every character outside
+// [a-z0-9], so punctuation/casing variants of the same logical tag collapse
+// to a single key (e.g. "admin.ivry.jp" and "admin_ivry_jp" and "AdminIvryJP"
+// all map to "adminivryjp").
+func normalizeTag(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/command/similarity.go
+++ b/internal/command/similarity.go
@@ -36,10 +36,7 @@ func levenshtein(a, b string) int {
 }
 
 func min3(a, b, c int) int {
-	m := min(b, a)
-	if c < m {
-		m = c
-	}
+	m := min(c, min(b, a))
 	return m
 }
 

--- a/internal/command/tag.go
+++ b/internal/command/tag.go
@@ -1,0 +1,82 @@
+package command
+
+import (
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/takai/htd/internal/output"
+	"github.com/takai/htd/internal/store"
+)
+
+func newTagCommand(c *container) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tag",
+		Short: "Tag-level operations across items",
+	}
+	cmd.AddCommand(newTagListCommand(c))
+	return cmd
+}
+
+func newTagListCommand(c *container) *cobra.Command {
+	var similar string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tags in use with item counts (use --similar to surface near-matches)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Filter{} pulls every item, active + archived, in one call.
+			items, err := store.List(c.cfg, store.Filter{})
+			if err != nil {
+				return err
+			}
+
+			counts := make(map[string]int)
+			for _, it := range items {
+				for _, t := range it.Tags {
+					counts[t]++
+				}
+			}
+
+			useSimilar := cmd.Flags().Changed("similar")
+			rows := make([]output.TagCount, 0, len(counts))
+			if useSimilar {
+				normInput := normalizeTag(similar)
+				for tag, count := range counts {
+					dist := levenshtein(tag, similar)
+					if dist > 3 && (normInput == "" || normalizeTag(tag) != normInput) && tag != similar {
+						continue
+					}
+					rows = append(rows, output.TagCount{Tag: tag, Count: count, Distance: dist})
+				}
+				sort.Slice(rows, func(i, j int) bool {
+					if rows[i].Distance != rows[j].Distance {
+						return rows[i].Distance < rows[j].Distance
+					}
+					if rows[i].Count != rows[j].Count {
+						return rows[i].Count > rows[j].Count
+					}
+					return rows[i].Tag < rows[j].Tag
+				})
+			} else {
+				for tag, count := range counts {
+					rows = append(rows, output.TagCount{Tag: tag, Count: count})
+				}
+				sort.Slice(rows, func(i, j int) bool {
+					if rows[i].Count != rows[j].Count {
+						return rows[i].Count > rows[j].Count
+					}
+					return rows[i].Tag < rows[j].Tag
+				})
+			}
+
+			c.printer.PrintTagCounts(rows, useSimilar)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&similar, "similar", "",
+		"Surface tags within Levenshtein distance 3 of this value, or whose normalized form (lowercase, [a-z0-9] only) collides with it")
+	return cmd
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -477,6 +477,49 @@ func toItemJSONList(items []*model.Item) []itemJSON {
 	return arr
 }
 
+// TagCount is one row of a `tag list` result: the tag string, its item count,
+// and (only used when --similar is set) its Levenshtein distance from the
+// query. Distance is presentation-only — it is rendered in the text table but
+// omitted from JSON to keep the JSON shape independent of flag combinations.
+type TagCount struct {
+	Tag      string
+	Count    int
+	Distance int
+}
+
+// PrintTagCounts prints `tag list` output. Text mode shows TAG\tCOUNT, plus a
+// DISTANCE column when withDistance is true (i.e. when --similar narrowed the
+// list). JSON mode always emits [{tag, count}, ...] with no distance field;
+// an empty slice still renders as [] rather than null.
+func (p *Printer) PrintTagCounts(rows []TagCount, withDistance bool) {
+	if p.json {
+		type tagCountJSON struct {
+			Tag   string `json:"tag"`
+			Count int    `json:"count"`
+		}
+		arr := make([]tagCountJSON, 0, len(rows))
+		for _, r := range rows {
+			arr = append(arr, tagCountJSON{Tag: r.Tag, Count: r.Count})
+		}
+		data, _ := json.Marshal(arr)
+		fmt.Fprintln(p.out, string(data))
+		return
+	}
+	tw := tabwriter.NewWriter(p.out, 0, 0, 2, ' ', 0)
+	if withDistance {
+		fmt.Fprintln(tw, "TAG\tCOUNT\tDISTANCE")
+		for _, r := range rows {
+			fmt.Fprintf(tw, "%s\t%d\t%d\n", r.Tag, r.Count, r.Distance)
+		}
+	} else {
+		fmt.Fprintln(tw, "TAG\tCOUNT")
+		for _, r := range rows {
+			fmt.Fprintf(tw, "%s\t%d\n", r.Tag, r.Count)
+		}
+	}
+	_ = tw.Flush()
+}
+
 // PrintLogItems prints a reflect log view: ID, KIND, STATUS, UPDATED_AT, TITLE.
 // JSON output is the same shape as PrintItems (full item fields).
 func (p *Printer) PrintLogItems(items []*model.Item) {

--- a/plugins/htd/agents/clarify.md
+++ b/plugins/htd/agents/clarify.md
@@ -42,7 +42,7 @@ You run the Clarify phase of the htd workflow. Your job is to turn every inbox i
    - Update the title if unclear: `htd clarify update <id> --title "<new>"`.
    - Link to a project: `htd organize link <id> <project-id>`. Only suggest this if a candidate shows up in a keyword-narrowed search: `htd item list --kind project --query '<keyword from the item>' --json`.
    - Schedule due/defer/review: `htd organize schedule <id> ...`. Only if the user mentions timing.
-   - Add tags: `htd item update <id> tags='[a,b]'`.
+   - Add tags: `htd item update <id> tags='[a,b]'`. Before proposing a fresh tag, sanity-check with `htd tag list --similar <candidate> --json` so you suggest the existing variant instead of inventing a new one.
 
 5. **Confirm before every mutating command.** Show the exact `htd` command you're about to run and wait for yes/ok. If the user says "just do it" or "go ahead for the rest", you may batch confirmations for this session, but still narrate each command.
 

--- a/plugins/htd/commands/capture.md
+++ b/plugins/htd/commands/capture.md
@@ -25,7 +25,7 @@ Ask the user in one turn for:
 - **Title** (required, short — one line).
 - **Body** (optional, free-form Markdown). Skip if they don't offer one.
 - **Source** (optional, e.g., `email`, `meeting`, `slack`).
-- **Tags** (optional, comma-separated).
+- **Tags** (optional, comma-separated). Before introducing a fresh tag, run `htd tag list --similar <candidate>` to surface existing variants and avoid drift (e.g., `ivry_job_scheduler` vs `ivry-job-scheduler`).
 
 Then build a single `htd capture add` invocation:
 

--- a/plugins/htd/skills/htd-workflow/SKILL.md
+++ b/plugins/htd/skills/htd-workflow/SKILL.md
@@ -131,6 +131,9 @@ All commands accept `--json` for machine-readable output and `--path` to target 
 - `htd item archive ID`
 - `htd item restore ID` — undo an accidental `engage done`/`cancel`/`discard`/`archive`; brings a terminal item back to `active` and moves it to `items/<kind>/`.
 
+**Tag**
+- `htd tag list [--similar TAG]` — enumerate every tag in use (across active + archived items) with item counts. Use `--similar <candidate>` **before introducing a new tag during capture/clarify** so variants like `ivry_job_scheduler` vs `ivry-job-scheduler` get surfaced instead of drifting. Tags are case-sensitive; the similarity check combines Levenshtein distance ≤ 3 with normalized-form (lowercase + alphanumeric-only) collision so punctuation/casing variants are caught too.
+
 **Reference (tool-scoped durable notes)** — see "References" above for the data type. All reference verbs accept `--tool TOOL` and default to `claude`.
 - `htd reference add --title TEXT [--body TEXT] [--tag TAG]... [--tool TOOL]` — tag with `type:user|feedback|area_of_focus|project|reference` to drive INDEX.md grouping; other tags fall into `## other`.
 - `htd reference get ID` — falls back to the archive automatically. Archived hits are marked `(archived)` in text mode and `archived: true` in JSON.


### PR DESCRIPTION
Closes #50.

## Summary

No way existed to enumerate tags in use, so variants drift silently as users and AI assistants type from short-term memory:

- `ivry_job_scheduler` vs `ivry-job-scheduler` vs `job_scheduler`
- `admin_ivry_jp` vs `admin.ivry.jp` vs `adminivryjp`

This PR adds `htd tag list` to survey every tag across active + archived items, with an optional `--similar TAG` narrowing flag.

## Design choices

- **Placement: new top-level `htd tag` group** (not `htd reflect tags`, not `htd item tags`). Tags form a cross-item noun and the issue explicitly anticipates `htd tag rename` later; opening a dedicated group avoids re-homing operations as the surface grows.
- **Active + archived in one call.** Drift prevention needs the full historical view; `store.List(cfg, Filter{})` already returns both.
- **Items only.** Reference `type:*` tags follow a formal enum and don't drift; a `--include-references` flag can be added later if needed.
- **Case-sensitive counts.** Anything else would mask actual drift instead of surfacing it.
- **Similarity** matches either Levenshtein distance ≤ 3 OR a normalized-form (lowercase + `[a-z0-9]`) collision — catches both transposition typos and punctuation variants in one pass.
- **JSON omits `distance`** so the JSON shape is independent of `--similar` (preventing a mode-dependent footgun for downstream consumers).

## Test plan

- [x] `mise run build` / `test` / `lint` green.
- [x] New tests (7): default sort, count tiebreaker, archived inclusion, Levenshtein similarity, normalization similarity, empty-repo JSON, JSON shape (no `distance` key).
- [x] Manual smoke covers empty-repo JSON, default listing, both similarity paths, and JSON shape.
- [x] Docs: `docs/cli.md` gets a new §10 with §11–13 renumbered; `README.md` quick reference; `plugins/htd/skills/htd-workflow/SKILL.md` cheat sheet; `plugins/htd/commands/capture.md` and `plugins/htd/agents/clarify.md` nudge agents to run `tag list --similar` before introducing a fresh tag.